### PR TITLE
Remove prepend of account name to custom service URL

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -319,7 +319,6 @@ public class AzureStorageBuilder extends Builder {
 						storageAcc = sa;
 
 						storageAcc.setBlobEndPointURL(Utils.getBlobEP(
-								storageAcc.getStorageAccName(),
 								storageAcc.getBlobEndPointURL()));
 						break;
 					}

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -429,11 +429,9 @@ public class WAStoragePublisher extends Recorder {
 						storageAccountInfo = sa;
 
 						if (storageAccountInfo != null) {
-							storageAccountInfo.setBlobEndPointURL(Utils
-									.getBlobEP(storageAccountInfo
-											.getStorageAccName(),
-											storageAccountInfo
-													.getBlobEndPointURL()));
+							storageAccountInfo.setBlobEndPointURL(
+								Utils.getBlobEP(storageAccountInfo.getBlobEndPointURL())
+							);
 						}
 						break;
 					}

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -167,7 +167,6 @@ public class WAStoragePublisher extends Recorder {
 				storageAcc = sa;
 				if (storageAcc != null) {
 					storageAcc.setBlobEndPointURL(Utils.getBlobEP(
-							storageAcc.getStorageAccName(),
 							storageAcc.getBlobEndPointURL()));
 				}
 				break;
@@ -343,8 +342,7 @@ public class WAStoragePublisher extends Recorder {
 
 			try {
 				// Get formatted blob end point URL.
-				was_blobEndPointURL = Utils.getBlobEP(was_storageAccName,
-						was_blobEndPointURL);
+				was_blobEndPointURL = Utils.getBlobEP(was_blobEndPointURL);
 				WAStorageClient.validateStorageAccount(was_storageAccName,
 						was_storageAccountKey, was_blobEndPointURL);
 			} catch (Exception e) {

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -156,15 +156,14 @@ public class Utils {
 			blobURL = blobURL.concat(FWD_SLASH);
 		}
 
-		if (blobURL.equals(DEF_BLOB_URL)) {
-			return DEF_BLOB_URL;
-		} else {
-			if (blobURL.indexOf(PRT_SEP) == -1) { // prepend http protocol if missing
-				blobURL = new StringBuilder().append(HTTP_PRT)
-						.append(blobURL)
-						.toString();
-			}
+		// prepend http protocol if missing
+		if (blobURL.indexOf(PRT_SEP) == -1) { 
+			blobURL = new StringBuilder()
+				.append(HTTP_PRT)
+				.append(blobURL)
+				.toString();
 		}
+
 		return blobURL;
 	}
 

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -141,12 +141,11 @@ public class Utils {
 	 * Returns formatted blob end point in case if a non-default one is
 	 * specified.
 	 * 
-	 * @param storageAccName
 	 * @param blobURL
 	 * @return DEF_BLOB_URL if blobURL is empty or blobURL is default one else
 	 *         returns formatted blob url.
 	 */
-	public static String getBlobEP(String storageAccName, String blobURL) {
+	public static String getBlobEP(String blobURL) {
 
 		if (isNullOrEmpty(blobURL)) {
 			return DEF_BLOB_URL;
@@ -160,12 +159,9 @@ public class Utils {
 		if (blobURL.equals(DEF_BLOB_URL)) {
 			return DEF_BLOB_URL;
 		} else {
-			if (blobURL.indexOf(PRT_SEP) != -1) { // insert storage account name
-				blobURL = blobURL.replace(PRT_SEP, PRT_SEP + storageAccName
-						+ ".");
-			} else { // insert http and storage account name
+			if (blobURL.indexOf(PRT_SEP) == -1) { // prepend http protocol if missing
 				blobURL = new StringBuilder().append(HTTP_PRT)
-						.append(storageAccName).append(".").append(blobURL)
+						.append(blobURL)
 						.toString();
 			}
 		}

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
@@ -54,5 +54,23 @@ public class WindowsAzureStorageTest extends TestCase {
 		// checking with not null and not empty string
 		assertEquals(false, Utils.isNullOrEmpty("xyz"));
 	}
+
+	@Test
+	public void testGetBlobEPReturnsDefaultURL() throws Exception {
+		// return default blob host given null URL
+		assertEquals(Utils.DEF_BLOB_URL, Utils.getBlobEP(null));
+		// return default blob host given the default blob URL
+		assertEquals(Utils.DEF_BLOB_URL, Utils.getBlobEP(Utils.DEF_BLOB_URL));
+	}
+
+	@Test
+	public void testGetBlobEPAddsHttpProtocolWhenNoProtocolPresent() throws Exception {
+		assertEquals("http://blob.host.domain.tld/", Utils.getBlobEP("blob.host.domain.tld"));
+	}
+
+	@Test
+	public void testGetBlobEPAddsTrailingForwardSlashWhenMissing() throws Exception {
+		assertEquals("https://blob.core.windows.net/", Utils.getBlobEP("https://blob.core.windows.net"));
+	}
 	
 }

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
@@ -12,13 +12,13 @@ public class WindowsAzureStorageTest extends TestCase {
 	@Test
 	public void testContainerName() throws Exception {
 		
-		// checking for container name lenth of 3 characters
+		// checking for container name length of 3 characters
 		assertEquals(true, Utils.validateContainerName("abc"));
 		
-		// checking for container name lenth of 5 characters
+		// checking for container name length of 5 characters
 		assertEquals(true, Utils.validateContainerName("1abc3"));
 		
-		// checking for container name lenth of 63 characters
+		// checking for container name length of 63 characters
 		assertEquals(true, Utils.validateContainerName("abcde12345abcde12345abcde12345abcde12345abcde12345abcde12345abc"));
 		
 		// checking for container name with dash (-) characters 


### PR DESCRIPTION
If one wants to use https://blob.core.windows.net/, or some other non-default URL to Azure Storage,
the host part of the URL will be prepended with the storage account of the build.

Example:

1. The blob service endpoint URL is set to https://blob.core.windows.net for account 'foo-account'
2. First build publishes its artefacts successfully to https://foo-account.blob.core.windows.net
3. Second build fails to publish the build artifacts with the following error message:

    ```
    Archiving artifacts
    Failed to validate storage account details. Please verify storage account name and key. If you are using a private or other Windows Azure cloud service, make sure that the blob endpoint url is correct.
    Storage Account name --->foo-account<----
    Blob end point url --->https://foo-account.foo-account.blob.core.windows.net/<----
    Build step 'Upload artifacts to Microsoft Azure Blob storage' changed build result to UNSTABLE
    Finished: UNSTABLE
    ```

This commit removes the prepend of the storage account name in the Utils.getBlobEP method and updates its usages.
Lacking an available development environment, tests for the new behavior were not added (help wanted with this).

This PR intends to fix #5