### PR TITLE
use latest azure storage SDK to avoid "The value for one of the HTTP headers is not in the correct format" error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /bin/
 /target/
 /work/
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
     
   <dependencies>
 	<dependency>
-		<groupId>com.microsoft.windowsazure.storage</groupId>
-		<artifactId>microsoft-windowsazure-storage-sdk</artifactId>
-		<version>0.6.0</version>
+		<groupId>com.microsoft.azure</groupId>
+		<artifactId>azure-storage</artifactId>
+		<version>4.0.0</version>
 	</dependency>
 	<dependency>
 		<groupId>commons-lang</groupId>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
@@ -43,21 +43,21 @@ import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.util.DirScanner.*;
 
-import com.microsoft.windowsazure.storage.CloudStorageAccount;
-import com.microsoft.windowsazure.storage.RetryNoRetry;
-import com.microsoft.windowsazure.storage.StorageCredentialsAccountAndKey;
-import com.microsoft.windowsazure.storage.StorageException;
-import com.microsoft.windowsazure.storage.blob.BlobContainerPermissions;
-import com.microsoft.windowsazure.storage.blob.BlobContainerPublicAccessType;
-import com.microsoft.windowsazure.storage.blob.BlobRequestOptions;
-import com.microsoft.windowsazure.storage.blob.CloudBlob;
-import com.microsoft.windowsazure.storage.blob.CloudBlobClient;
-import com.microsoft.windowsazure.storage.blob.CloudBlobContainer;
-import com.microsoft.windowsazure.storage.blob.CloudBlobDirectory;
-import com.microsoft.windowsazure.storage.blob.CloudBlockBlob;
-import com.microsoft.windowsazure.storage.blob.ListBlobItem;
-import com.microsoft.windowsazure.storage.blob.SharedAccessBlobPermissions;
-import com.microsoft.windowsazure.storage.blob.SharedAccessBlobPolicy;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.RetryNoRetry;
+import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobContainerPermissions;
+import com.microsoft.azure.storage.blob.BlobContainerPublicAccessType;
+import com.microsoft.azure.storage.blob.BlobRequestOptions;
+import com.microsoft.azure.storage.blob.CloudBlob;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlobDirectory;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.microsoft.azure.storage.blob.ListBlobItem;
+import com.microsoft.azure.storage.blob.SharedAccessBlobPermissions;
+import com.microsoft.azure.storage.blob.SharedAccessBlobPolicy;
 import com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher.UploadType;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
 import com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException;
@@ -150,7 +150,7 @@ public class WAStorageClient {
 		if (!allowRetry) {
 			// Setting no retry policy
 			RetryNoRetry rnr = new RetryNoRetry();
-			serviceClient.setRetryPolicyFactory(rnr);
+			serviceClient.getDefaultRequestOptions().setRetryPolicyFactory(rnr);
 		}
 
 		container = serviceClient.getContainerReference(containerName);


### PR DESCRIPTION
Hi, this is a very simple fix, just upgrading the SDK version.
