### PR TITLE
Make storage safe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <description>Uploads build artifacts or downloads build dependencies using Azure storage</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Windows+Azure+Storage+Plugin</url>
   
-  <properties>
+    <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	<jenkins.version>1.645</jenkins.version>
@@ -23,12 +23,12 @@
 	<maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
     
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0 (the "License")</name>
-      <comments>Licensed under the Apache License, Version 2.0 (the "License").</comments>
-    </license>
-  </licenses>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0 (the "License")</name>
+            <comments>Licensed under the Apache License, Version 2.0 (the "License").</comments>
+        </license>
+    </licenses>
   
   <developers>
     	<developer>
@@ -42,12 +42,12 @@
       		<email>arroyc@microsoft.com</email>
     	</developer>
   </developers>
-    
-  <dependencies>
-	<dependency>
-		<groupId>com.microsoft.azure</groupId>
-		<artifactId>azure-storage</artifactId>
-		<version>4.4.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-storage</artifactId>
+            <version>4.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
@@ -56,11 +56,11 @@
             <version>1.645<!-- replace this with the version you want--></version>
             <scope>test</scope>
         </dependency>
-	<dependency>
-		<groupId>commons-lang</groupId>
-		<artifactId>commons-lang</artifactId>
-		<version>2.3</version>
-	</dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.3</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
@@ -84,28 +84,38 @@
             <version>1.3</version>
             <optional>true</optional>
         </dependency>
-  </dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1.21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.3</version>
+        </dependency>
+    </dependencies>
    
-   <scm>
-		<connection>scm:git:ssh://github.com/jenkinsci/windows-azure-storage-plugin.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/windows-azure-storage-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/windows-azure-storage-plugin</url>
-     <tag>HEAD</tag>
-  </scm>
+    <scm>
+        <connection>scm:git:ssh://github.com/jenkinsci/windows-azure-storage-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/windows-azure-storage-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/windows-azure-storage-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
   
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
   
   <build>
 	<plugins>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -15,7 +15,11 @@
  */
 package com.microsoftopentechnologies.windowsazurestorage;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
+import com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials;
 import com.microsoftopentechnologies.windowsazurestorage.helper.Utils;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
@@ -27,6 +31,7 @@ import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -34,15 +39,18 @@ import hudson.model.TaskListener;
 import hudson.plugins.copyartifact.BuildFilter;
 import hudson.plugins.copyartifact.BuildSelector;
 import hudson.plugins.copyartifact.StatusBuildSelector;
+import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
 import hudson.util.ListBoxModel;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -59,13 +67,17 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
     private final boolean includeArchiveZips;
     private final BuildSelector buildSelector;
     private final String projectName;
+    private final String storageCredentialId;
+
+    private transient final AzureCredentials.StorageAccountCredential storageCreds;
 
     public static class DownloadType {
+
         public final String type;
         public final String containerName;
         public final String projectName;
         BuildSelector buildSelector;
-        
+
         @DataBoundConstructor
         public DownloadType(final String value, final String containerName, final String projectName, final BuildSelector buildSelector) {
             this.type = value;
@@ -81,14 +93,16 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundConstructor
     public AzureStorageBuilder(
-            final String storageAccName,
+            final String storageCredentialId,
             final DownloadType downloadType,
             final String includeFilesPattern,
             final String excludeFilesPattern,
             final String downloadDirLoc,
             final boolean flattenDirectories,
             final boolean includeArchiveZips) {
-        this.storageAccName = storageAccName;
+        this.storageCredentialId = storageCredentialId;
+        this.storageCreds = AzureCredentials.getStorageAccountCredential(storageCredentialId);
+        this.storageAccName = storageCreds.getStorageAccountName();
         this.downloadType = downloadType.type;
         this.containerName = downloadType.containerName;
         this.includeFilesPattern = includeFilesPattern;
@@ -101,11 +115,11 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
     }
 
     public BuildSelector getBuildSelector() {
-	return buildSelector;
+        return buildSelector;
     }
 
     public String getStorageAccName() {
-	return storageAccName;
+        return storageAccName;
     }
 
     public String getDownloadType() {
@@ -113,35 +127,35 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
     }
 
     public String getContainerName() {
-	return containerName;
+        return containerName;
     }
 
     public String getProjectName() {
-	return projectName;
+        return projectName;
     }
 
     public String getIncludeFilesPattern() {
-	return includeFilesPattern;
+        return includeFilesPattern;
     }
 
     public String getExcludeFilesPattern() {
-	return excludeFilesPattern;
+        return excludeFilesPattern;
     }
 
     public String getDownloadDirLoc() {
-	return downloadDirLoc;
+        return downloadDirLoc;
     }
 
     public boolean isIncludeArchiveZips() {
-	return includeArchiveZips;
+        return includeArchiveZips;
     }
 
     public boolean isFlattenDirectories() {
-	return flattenDirectories;
+        return flattenDirectories;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-	return BuildStepMonitor.NONE;
+        return BuildStepMonitor.NONE;
     }
 
     /**
@@ -153,223 +167,229 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
      */
     @Override
     public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener) {
-	StorageAccountInfo strAcc = null;
-	try {
-	    final EnvVars envVars = run.getEnvironment(listener);
+        StorageAccountInfo strAcc = null;
+        try {
+            final EnvVars envVars = run.getEnvironment(listener);
 
-	    // Get storage account
-	    strAcc = getDescriptor().getStorageAccount(storageAccName);
+            // Get storage account
+            strAcc = AzureCredentials.convertToStorageAccountInfo(this.storageCreds);
 
-	    // Resolve include patterns
-	    String expIncludePattern = Util.replaceMacro(includeFilesPattern, envVars);
+            // Resolve include patterns
+            String expIncludePattern = Util.replaceMacro(includeFilesPattern, envVars);
 
-	    // Resolve exclude patterns
-	    String expExcludePattern = Util.replaceMacro(excludeFilesPattern, envVars);
+            // Resolve exclude patterns
+            String expExcludePattern = Util.replaceMacro(excludeFilesPattern, envVars);
 
-	    String expProjectName = Util.replaceMacro(projectName, envVars);
+            String expProjectName = Util.replaceMacro(projectName, envVars);
 
-	    String expContainerName = Util.replaceMacro(containerName, envVars);
+            String expContainerName = Util.replaceMacro(containerName, envVars);
 
-	    // If the include is empty, make **/*
-	    if (Utils.isNullOrEmpty(expIncludePattern)) {
-		expIncludePattern = "**/*";
-	    }
+            // If the include is empty, make **/*
+            if (Utils.isNullOrEmpty(expIncludePattern)) {
+                expIncludePattern = "**/*";
+            }
 
-	    // Exclude archive.zip by default.
-	    if (!includeArchiveZips) {
-		if (expExcludePattern != null) {
-		    expExcludePattern += ",archive.zip";
-		} else {
-		    expExcludePattern = "archive.zip";
-		}
-	    }
+            // Exclude archive.zip by default.
+            if (!includeArchiveZips) {
+                if (expExcludePattern != null) {
+                    expExcludePattern += ",archive.zip";
+                } else {
+                    expExcludePattern = "archive.zip";
+                }
+            }
 
-	    // Validate input data
-	    validateData(run, listener, strAcc);
+            // Validate input data
+            validateData(run, listener, strAcc);
 
-	    int filesDownloaded = 0;
-	    if (downloadType == null || downloadType.equals("container")) { /*the null check is backward compatibility*/
-		    filesDownloaded += WAStorageClient.download(run, launcher, listener,
-			    strAcc, expIncludePattern, expExcludePattern, Util.replaceMacro(downloadDirLoc, envVars),
-			    flattenDirectories, workspace, expContainerName);
-	    } else {
-		    Job<?, ?> job = Jenkins.getInstance().getItemByFullName(expProjectName, Job.class);
-		    if (job != null) {
-			// Resolve download location
-			BuildFilter filter = new BuildFilter();
-			Run source = getBuildSelector().getBuild(job, envVars, filter, run);
+            int filesDownloaded = 0;
+            if (downloadType == null || downloadType.equals("container")) {
+                /*the null check is backward compatibility*/
+                filesDownloaded += WAStorageClient.download(run, launcher, listener,
+                        strAcc, expIncludePattern, expExcludePattern, Util.replaceMacro(downloadDirLoc, envVars),
+                        flattenDirectories, workspace, expContainerName);
+            } else {
+                Job<?, ?> job = Jenkins.getInstance().getItemByFullName(expProjectName, Job.class);
+                if (job != null) {
+                    // Resolve download location
+                    BuildFilter filter = new BuildFilter();
+                    Run source = getBuildSelector().getBuild(job, envVars, filter, run);
 
-			if (source instanceof MatrixBuild) {
-				for (Run r : ((MatrixBuild) source).getExactRuns()) {
-				    filesDownloaded += downloadArtifacts(r, run, launcher, expIncludePattern, expExcludePattern, listener, strAcc, workspace);
-				}
-			} else {
-				filesDownloaded += downloadArtifacts(source, run, launcher, expIncludePattern, expExcludePattern, listener, strAcc, workspace);
-			}
-		} else {
-		    listener.getLogger().println(Messages.AzureStorageBuilder_job_invalid(expProjectName));
-		    run.setResult(Result.UNSTABLE);
-		}
-	    }
+                    if (source instanceof MatrixBuild) {
+                        for (Run r : ((MatrixBuild) source).getExactRuns()) {
+                            filesDownloaded += downloadArtifacts(r, run, launcher, expIncludePattern, expExcludePattern, listener, strAcc, workspace);
+                        }
+                    } else {
+                        filesDownloaded += downloadArtifacts(source, run, launcher, expIncludePattern, expExcludePattern, listener, strAcc, workspace);
+                    }
+                } else {
+                    listener.getLogger().println(Messages.AzureStorageBuilder_job_invalid(expProjectName));
+                    run.setResult(Result.UNSTABLE);
+                }
+            }
 
-	    if (filesDownloaded == 0) { // Mark build unstable if no files are
-		    // downloaded
-		    listener.getLogger().println(Messages.AzureStorageBuilder_nofiles_downloaded());
-		    run.setResult(Result.UNSTABLE);
-	    } else {
-		    listener.getLogger().println(Messages.AzureStorageBuilder_files_downloaded_count(filesDownloaded));
-	    }
+            if (filesDownloaded == 0) { // Mark build unstable if no files are
+                // downloaded
+                listener.getLogger().println(Messages.AzureStorageBuilder_nofiles_downloaded());
+                run.setResult(Result.UNSTABLE);
+            } else {
+                listener.getLogger().println(Messages.AzureStorageBuilder_files_downloaded_count(filesDownloaded));
+            }
 
-	} catch (Exception e) {
-	    e.printStackTrace(listener.error(Messages.AzureStorageBuilder_download_err(strAcc.getStorageAccName())));
-	    run.setResult(Result.UNSTABLE);
-	}
+        } catch (Exception e) {
+            e.printStackTrace(listener.error(Messages.AzureStorageBuilder_download_err(strAcc.getStorageAccName())));
+            run.setResult(Result.UNSTABLE);
+        }
     }
 
     private int downloadArtifacts(Run<?, ?> source, Run<?, ?> run, Launcher launcher, String includeFilter, String excludeFilter, TaskListener listener, StorageAccountInfo strAcc, FilePath workspace) {
-	int filesDownloaded = 0;
-	try {
-	    final EnvVars envVars = run.getEnvironment(listener);
-	    final AzureBlobAction action = source.getAction(AzureBlobAction.class);
-	    List<AzureBlob> blob = action.getIndividualBlobs();
-	    if (action.getZipArchiveBlob() != null && includeArchiveZips) {
-		blob.addAll(Arrays.asList(action.getZipArchiveBlob()));
-	    }
+        int filesDownloaded = 0;
+        try {
+            final EnvVars envVars = run.getEnvironment(listener);
+            final AzureBlobAction action = source.getAction(AzureBlobAction.class);
+            List<AzureBlob> blob = action.getIndividualBlobs();
+            if (action.getZipArchiveBlob() != null && includeArchiveZips) {
+                blob.addAll(Arrays.asList(action.getZipArchiveBlob()));
+            }
 
-	    // Resolve download location
-	    String downloadDir = Util.replaceMacro(downloadDirLoc, envVars);
-	    filesDownloaded = WAStorageClient.download(run, launcher, listener,
-		    strAcc, blob, includeFilter, excludeFilter,
-		    downloadDir, flattenDirectories, workspace);
+            // Resolve download location
+            String downloadDir = Util.replaceMacro(downloadDirLoc, envVars);
+            filesDownloaded = WAStorageClient.download(run, launcher, listener,
+                    strAcc, blob, includeFilter, excludeFilter,
+                    downloadDir, flattenDirectories, workspace);
 
-	} catch (Exception e) {
-	    run.setResult(Result.UNSTABLE);
-	}
+        } catch (Exception e) {
+            run.setResult(Result.UNSTABLE);
+        }
 
-	return filesDownloaded;
+        return filesDownloaded;
     }
 
     private void validateData(Run<?, ?> run, TaskListener listener,
-	    StorageAccountInfo strAcc) {
+            StorageAccountInfo strAcc) {
 
-	// No need to download artifacts if build failed
-	if (run.getResult() == Result.FAILURE) {
-	    listener.getLogger().println(
-		    Messages.AzureStorageBuilder_build_failed_err());
-	}
+        // No need to download artifacts if build failed
+        if (run.getResult() == Result.FAILURE) {
+            listener.getLogger().println(
+                    Messages.AzureStorageBuilder_build_failed_err());
+        }
 
-	if (strAcc == null) {
-	    listener.getLogger().println(
-		    Messages.WAStoragePublisher_storage_account_err());
-	    run.setResult(Result.UNSTABLE);
-	}
+        if (strAcc == null) {
+            listener.getLogger().println(
+                    Messages.WAStoragePublisher_storage_account_err());
+            run.setResult(Result.UNSTABLE);
+        }
 
-	// Check if storage account credentials are valid
-	try {
-	    WAStorageClient.validateStorageAccount(strAcc);
-	} catch (Exception e) {
-	    listener.getLogger().println(Messages.Client_SA_val_fail());
-	    listener.getLogger().println(strAcc.getStorageAccName());
-	    listener.getLogger().println(strAcc.getBlobEndPointURL());
-	    run.setResult(Result.UNSTABLE);
-	}
+        // Check if storage account credentials are valid
+        try {
+            WAStorageClient.validateStorageAccount(strAcc);
+        } catch (Exception e) {
+            listener.getLogger().println(Messages.Client_SA_val_fail());
+            listener.getLogger().println(strAcc.getStorageAccName());
+            listener.getLogger().println(strAcc.getBlobEndPointURL());
+            run.setResult(Result.UNSTABLE);
+        }
     }
 
     @Override
     public AzureStorageBuilderDesc getDescriptor() {
-	// see Descriptor javadoc for more about what a descriptor is.
-	return (AzureStorageBuilderDesc) super.getDescriptor();
+        // see Descriptor javadoc for more about what a descriptor is.
+        return (AzureStorageBuilderDesc) super.getDescriptor();
     }
 
     @Extension
     public static final class AzureStorageBuilderDesc extends
-	    BuildStepDescriptor<Builder> {
+            BuildStepDescriptor<Builder> {
 
-	@Override
-	public boolean isApplicable(
-		@SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType) {
-	    return true;
-	}
+        @Override
+        public boolean isApplicable(
+                @SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType) {
+            return true;
+        }
 
-	public AzureStorageBuilderDesc() {
-	    super();
-	    load();
-	}
+        public AzureStorageBuilderDesc() {
+            super();
+            load();
+        }
 
-	public ListBoxModel doFillStorageAccNameItems() {
-	    ListBoxModel m = new ListBoxModel();
-	    StorageAccountInfo[] StorageAccounts = getStorageAccounts();
+        public ListBoxModel doFillStorageAccNameItems() {
+            ListBoxModel m = new ListBoxModel();
+            StorageAccountInfo[] StorageAccounts = getStorageAccounts();
 
-	    if (StorageAccounts != null) {
-		for (StorageAccountInfo storageAccount : StorageAccounts) {
-		    m.add(storageAccount.getStorageAccName());
-		}
-	    }
-	    return m;
-	}
+            if (StorageAccounts != null) {
+                for (StorageAccountInfo storageAccount : StorageAccounts) {
+                    m.add(storageAccount.getStorageAccName());
+                }
+            }
+            return m;
+        }
 
-	public AutoCompletionCandidates doAutoCompleteProjectName(@QueryParameter String value) {
-	    AutoCompletionCandidates projectList = new AutoCompletionCandidates();
-	    for (AbstractProject<?, ?> project : Jenkins.getInstance().getItems(AbstractProject.class)) {
-		if (project.getName().toLowerCase().startsWith(value.toLowerCase())) {
-		    projectList.add(project.getName());
-		}
-	    }
-	    return projectList;
-	}
+        public ListBoxModel doFillStorageCredentialIdItems(@AncestorInPath Item owner) {
 
-	public boolean configure(StaplerRequest req, JSONObject formData)
-		throws FormException {
-	    save();
-	    return super.configure(req, formData);
-	}
+            return new StandardListBoxModel().withAll(CredentialsProvider.lookupCredentials(AzureCredentials.class, owner, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()));
+        }
 
-	public String getDisplayName() {
-	    return Messages.AzureStorageBuilder_displayName();
-	}
+        public AutoCompletionCandidates doAutoCompleteProjectName(@QueryParameter String value) {
+            AutoCompletionCandidates projectList = new AutoCompletionCandidates();
+            for (AbstractProject<?, ?> project : Jenkins.getInstance().getItems(AbstractProject.class)) {
+                if (project.getName().toLowerCase().startsWith(value.toLowerCase())) {
+                    projectList.add(project.getName());
+                }
+            }
+            return projectList;
+        }
 
-	public StorageAccountInfo[] getStorageAccounts() {
-	    WAStoragePublisher.WAStorageDescriptor publisherDescriptor = Jenkins
-		    .getInstance().getDescriptorByType(
-			    WAStoragePublisher.WAStorageDescriptor.class);
+        public boolean configure(StaplerRequest req, JSONObject formData)
+                throws FormException {
+            save();
+            return super.configure(req, formData);
+        }
 
-	    StorageAccountInfo[] sa = publisherDescriptor.getStorageAccounts();
+        public String getDisplayName() {
+            return Messages.AzureStorageBuilder_displayName();
+        }
 
-	    return sa;
-	}
+        public StorageAccountInfo[] getStorageAccounts() {
+            WAStoragePublisher.WAStorageDescriptor publisherDescriptor = Jenkins
+                    .getInstance().getDescriptorByType(
+                            WAStoragePublisher.WAStorageDescriptor.class);
 
-	/**
-	 * Returns storage account object
-	 *
-	 * @param storageAccountName
-	 * @return StorageAccount
-	 */
-	public StorageAccountInfo getStorageAccount(String storageAccountName) {
-	    if ((storageAccountName == null)
-		    || (storageAccountName.trim().length() == 0)) {
-		return null;
-	    }
+            StorageAccountInfo[] sa = publisherDescriptor.getStorageAccounts();
 
-	    StorageAccountInfo storageAcc = null;
-	    StorageAccountInfo[] StorageAccounts = getStorageAccounts();
+            return sa;
+        }
 
-	    if (StorageAccounts != null) {
-		for (StorageAccountInfo sa : StorageAccounts) {
-		    if (sa.getStorageAccName().equals(storageAccountName)) {
-			storageAcc = sa;
+        /**
+         * Returns storage account object
+         *
+         * @param storageAccountName
+         * @return StorageAccount
+         */
+        public StorageAccountInfo getStorageAccount(String storageAccountName) {
+            if ((storageAccountName == null)
+                    || (storageAccountName.trim().length() == 0)) {
+                return null;
+            }
 
-			storageAcc.setBlobEndPointURL(Utils.getBlobEP(
-				storageAcc.getBlobEndPointURL()));
-			break;
-		    }
-		}
-	    }
-	    return storageAcc;
-	}
+            StorageAccountInfo storageAcc = null;
+            StorageAccountInfo[] StorageAccounts = getStorageAccounts();
 
-	public DescriptorExtensionList<BuildSelector, Descriptor<BuildSelector>> getAvailableBuildSelectorList() {
-	    return DescriptorExtensionList.createDescriptorList(Jenkins.getInstance(), BuildSelector.class);
-	}
+            if (StorageAccounts != null) {
+                for (StorageAccountInfo sa : StorageAccounts) {
+                    if (sa.getStorageAccName().equals(storageAccountName)) {
+                        storageAcc = sa;
+
+                        storageAcc.setBlobEndPointURL(Utils.getBlobEP(
+                                storageAcc.getBlobEndPointURL()));
+                        break;
+                    }
+                }
+            }
+            return storageAcc;
+        }
+
+        public DescriptorExtensionList<BuildSelector, Descriptor<BuildSelector>> getAvailableBuildSelectorList() {
+            return DescriptorExtensionList.createDescriptorList(Jenkins.getInstance(), BuildSelector.class);
+        }
 
     }
 }

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
@@ -32,6 +32,7 @@ import com.microsoft.azure.storage.blob.SharedAccessBlobPolicy;
 import com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher.UploadType;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
 import com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException;
+import com.microsoftopentechnologies.windowsazurestorage.helper.Constants;
 import com.microsoftopentechnologies.windowsazurestorage.helper.Utils;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -119,7 +120,7 @@ public class WAStorageClient {
 
 	credentials = new StorageCredentialsAccountAndKey(accName, storageAccount.getStorageAccountKey());
 
-	if (Utils.isNullOrEmpty(blobURL) || blobURL.equals(Utils.DEF_BLOB_URL)) {
+	if (Utils.isNullOrEmpty(blobURL) || blobURL.equals(Constants.DEF_BLOB_URL)) {
 	    cloudStorageAccount = new CloudStorageAccount(credentials);
 	} else {
 	    cloudStorageAccount = new CloudStorageAccount(credentials, new URI(
@@ -275,8 +276,8 @@ public class WAStorageClient {
 
 			if (Utils.isNullOrEmpty(embeddedVP)) {
 			    embeddedVP = null;
-			} else if (!embeddedVP.endsWith(Utils.FWD_SLASH)) {
-			    embeddedVP = embeddedVP + Utils.FWD_SLASH;
+			} else if (!embeddedVP.endsWith(Constants.FWD_SLASH)) {
+			    embeddedVP = embeddedVP + Constants.FWD_SLASH;
 			}
 		    }
 		    fileName = fileName.substring(0, embVPSepIndex);

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -15,6 +15,15 @@
  */
 package com.microsoftopentechnologies.windowsazurestorage;
 
+import com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
 import com.microsoftopentechnologies.windowsazurestorage.helper.Utils;
 import hudson.EnvVars;
@@ -24,9 +33,11 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
+import hudson.model.Item;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -48,6 +59,9 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
 
@@ -114,118 +128,138 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
 
     private final boolean doNotWaitForPreviousBuild;
 
+    private final String storageCredentialId;
+
+    private transient final AzureCredentials.StorageAccountCredential storageCreds;
+
     public enum UploadType {
-	INDIVIDUAL,
-	ZIP,
-	BOTH,
-	INVALID;
+        INDIVIDUAL,
+        ZIP,
+        BOTH,
+        INVALID;
     }
 
     @DataBoundConstructor
-    public WAStoragePublisher(final String storageAccName,
-	    final String filesPath, final String excludeFilesPath, final String containerName,
-	    final boolean cntPubAccess, final String virtualPath,
-	    final boolean cleanUpContainer, final boolean allowAnonymousAccess,
-	    final boolean uploadArtifactsOnlyIfSuccessful,
-	    final boolean doNotFailIfArchivingReturnsNothing,
-	    final boolean doNotUploadIndividualFiles,
-	    final boolean uploadZips,
-	    final boolean doNotWaitForPreviousBuild) {
-	super();
-	this.storageAccName = storageAccName;
-	this.filesPath = filesPath.trim();
-	this.excludeFilesPath = excludeFilesPath.trim();
-	this.containerName = containerName.trim();
-	this.cntPubAccess = cntPubAccess;
-	this.virtualPath = virtualPath.trim();
-	this.cleanUpContainer = cleanUpContainer;
-	this.allowAnonymousAccess = allowAnonymousAccess;
-	this.uploadArtifactsOnlyIfSuccessful = uploadArtifactsOnlyIfSuccessful;
-	this.doNotFailIfArchivingReturnsNothing = doNotFailIfArchivingReturnsNothing;
-	this.doNotUploadIndividualFiles = doNotUploadIndividualFiles;
-	this.uploadZips = uploadZips;
-	this.doNotWaitForPreviousBuild = doNotWaitForPreviousBuild;
+    public WAStoragePublisher(final String storageCredentialId,
+            final String filesPath, final String excludeFilesPath, final String containerName,
+            final boolean cntPubAccess, final String virtualPath,
+            final boolean cleanUpContainer, final boolean allowAnonymousAccess,
+            final boolean uploadArtifactsOnlyIfSuccessful,
+            final boolean doNotFailIfArchivingReturnsNothing,
+            final boolean doNotUploadIndividualFiles,
+            final boolean uploadZips,
+            final boolean doNotWaitForPreviousBuild) {
+        super();
+        this.storageCreds = AzureCredentials.getStorageAccountCredential(storageCredentialId);
+        this.filesPath = filesPath.trim();
+        this.excludeFilesPath = excludeFilesPath.trim();
+        this.containerName = containerName.trim();
+        this.cntPubAccess = cntPubAccess;
+        this.virtualPath = virtualPath.trim();
+        this.cleanUpContainer = cleanUpContainer;
+        this.allowAnonymousAccess = allowAnonymousAccess;
+        this.uploadArtifactsOnlyIfSuccessful = uploadArtifactsOnlyIfSuccessful;
+        this.doNotFailIfArchivingReturnsNothing = doNotFailIfArchivingReturnsNothing;
+        this.doNotUploadIndividualFiles = doNotUploadIndividualFiles;
+        this.uploadZips = uploadZips;
+        this.doNotWaitForPreviousBuild = doNotWaitForPreviousBuild;
+        this.storageCredentialId = storageCredentialId;
+        this.storageAccName = this.storageCreds.getStorageAccountName();
     }
 
     public String getFilesPath() {
-	return filesPath;
+        return filesPath;
     }
 
     public String getExcludeFilesPath() {
-	return excludeFilesPath;
+        return excludeFilesPath;
     }
 
     public String getContainerName() {
-	return containerName;
+        return containerName;
     }
 
     public boolean isCntPubAccess() {
-	return cntPubAccess;
+        return cntPubAccess;
     }
 
     public boolean isCleanUpContainer() {
-	return cleanUpContainer;
+        return cleanUpContainer;
     }
 
     public boolean isAllowAnonymousAccess() {
-	return allowAnonymousAccess;
+        return allowAnonymousAccess;
     }
 
     public boolean isDoNotFailIfArchivingReturnsNothing() {
-	return doNotFailIfArchivingReturnsNothing;
+        return doNotFailIfArchivingReturnsNothing;
     }
 
     public boolean isUploadArtifactsOnlyIfSuccessful() {
-	return uploadArtifactsOnlyIfSuccessful;
+        return uploadArtifactsOnlyIfSuccessful;
     }
 
     public boolean isUploadZips() {
-	return uploadZips;
+        return uploadZips;
     }
 
     public boolean isDoNotUploadIndividualFiles() {
-	return doNotUploadIndividualFiles;
+        return doNotUploadIndividualFiles;
     }
 
     public boolean isDoNotWaitForPreviousBuild() {
-	return doNotWaitForPreviousBuild;
+        return doNotWaitForPreviousBuild;
+    }
+
+    public String getStorageCredentialId() {
+        return storageCredentialId;
+    }
+
+    public AzureCredentials.StorageAccountCredential getStorageCreds() {
+
+        if (storageCreds == null && storageCredentialId != null) {
+            return AzureCredentials.getStorageAccountCredential(this.storageCredentialId);
+        }
+
+        return storageCreds;
     }
 
     private UploadType computeArtifactUploadType(final boolean uploadZips, final boolean doNotUploadIndividualFiles) {
-	if (uploadZips && !doNotUploadIndividualFiles) {
-	    return UploadType.BOTH;
-	} else if (!uploadZips && !doNotUploadIndividualFiles) {
-	    return UploadType.INDIVIDUAL;
-	} else if (uploadZips && doNotUploadIndividualFiles) {
-	    return UploadType.ZIP;
-	} else {
-	    return UploadType.INVALID;
-	}
+        if (uploadZips && !doNotUploadIndividualFiles) {
+            return UploadType.BOTH;
+        } else if (!uploadZips && !doNotUploadIndividualFiles) {
+            return UploadType.INDIVIDUAL;
+        } else if (uploadZips && doNotUploadIndividualFiles) {
+            return UploadType.ZIP;
+        } else {
+            return UploadType.INVALID;
+        }
     }
 
     public UploadType getArtifactUploadType() {
-	return computeArtifactUploadType(this.uploadZips, this.doNotUploadIndividualFiles);
+        return computeArtifactUploadType(this.uploadZips, this.doNotUploadIndividualFiles);
     }
 
     public String getStorageAccName() {
-	return storageAccName;
+        return storageAccName;
     }
 
     public String getVirtualPath() {
-	return virtualPath;
+        return virtualPath;
     }
 
     public WAStorageDescriptor getDescriptor() {
-	return (WAStorageDescriptor) super.getDescriptor();
+        WAStorageDescriptor x = (WAStorageDescriptor) super.getDescriptor();
+        return (WAStorageDescriptor) super.getDescriptor();
     }
 
     //Defines project actions
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
-	AzureBlobProjectAction projectAction = new AzureBlobProjectAction(project);
-	List<Action> projectActions = new ArrayList<Action>();
-	projectActions.add(projectAction);
+        AzureBlobProjectAction projectAction = new AzureBlobProjectAction(project);
+        List<Action> projectActions = new ArrayList<Action>();
+        projectActions.add(projectAction);
 
-	return Collections.unmodifiableList(projectActions);
+        return Collections.unmodifiableList(projectActions);
     }
 
     /**
@@ -235,304 +269,325 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
      * @return StorageAccount
      */
     public StorageAccountInfo getStorageAccount() {
-	StorageAccountInfo storageAcc = null;
-	for (StorageAccountInfo sa : getDescriptor().getStorageAccounts()) {
-	    if (sa.getStorageAccName().equals(storageAccName)) {
-		storageAcc = sa;
-		storageAcc.setBlobEndPointURL(Utils.getBlobEP(
-			storageAcc.getBlobEndPointURL()));
-		break;
-	    }
-	}
-	return storageAcc;
+        StorageAccountInfo storageAcc = null;
+        storageAcc = AzureCredentials.convertToStorageAccountInfo(this.getStorageCreds());
+
+        return storageAcc;
     }
 
     public String replaceMacro(String s, Map<String, String> props, Locale locale) {
-	return Util.replaceMacro(s, props).trim().toLowerCase(locale);
+        return Util.replaceMacro(s, props).trim().toLowerCase(locale);
     }
 
     public String replaceMacro(String s, Map<String, String> props) {
-	return Util.replaceMacro(s, props).trim();
+        return Util.replaceMacro(s, props).trim();
     }
 
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
 
-	// Get storage account and set formatted blob endpoint url.
-	StorageAccountInfo strAcc = getStorageAccount();
-	final EnvVars envVars = run.getEnvironment(listener);
+        // Get storage account and set formatted blob endpoint url.
+        StorageAccountInfo strAcc = getStorageAccount();
+        //StorageAccountInfo strAcc = get
+        final EnvVars envVars = run.getEnvironment(listener);
 
-	// Resolve container name
-	String expContainerName = replaceMacro(containerName, envVars, Locale.ENGLISH);
+        // Resolve container name
+        String expContainerName = replaceMacro(containerName, envVars, Locale.ENGLISH);
 
-	if (!validateData(run, listener, strAcc, expContainerName)) {
-	    throw new IOException("Plugin can not continue, until previous errors are addressed");
-	}
+        if (!validateData(run, listener, strAcc, expContainerName)) {
+            throw new IOException("Plugin can not continue, until previous errors are addressed");
+        }
 
-	// Resolve file path
-	String expFP = replaceMacro(filesPath, envVars);
+        // Resolve file path
+        String expFP = replaceMacro(filesPath, envVars);
 
-	// Resolve exclude paths
-	String excludeFP = replaceMacro(excludeFilesPath, envVars);
+        // Resolve exclude paths
+        String excludeFP = replaceMacro(excludeFilesPath, envVars);
 
-	// Resolve virtual path
-	String expVP = replaceMacro(virtualPath, envVars);
+        // Resolve virtual path
+        String expVP = replaceMacro(virtualPath, envVars);
 
-	if (!(Utils.isNullOrEmpty(expVP) || expVP.endsWith(Utils.FWD_SLASH))) {
-	    expVP += Utils.FWD_SLASH;
-	}
+        if (!(Utils.isNullOrEmpty(expVP) || expVP.endsWith(Utils.FWD_SLASH))) {
+            expVP += Utils.FWD_SLASH;
+        }
 
-	try {
-	    List<AzureBlob> individualBlobs = new ArrayList<AzureBlob>();
-	    List<AzureBlob> archiveBlobs = new ArrayList<AzureBlob>();
+        try {
+            List<AzureBlob> individualBlobs = new ArrayList<AzureBlob>();
+            List<AzureBlob> archiveBlobs = new ArrayList<AzureBlob>();
 
-	    int filesUploaded = WAStorageClient.upload(run, launcher, listener, strAcc,
-		    expContainerName, cntPubAccess, cleanUpContainer, expFP,
-		    expVP, excludeFP, getArtifactUploadType(), individualBlobs, archiveBlobs, ws);
+            int filesUploaded = WAStorageClient.upload(run, launcher, listener, strAcc,
+                    expContainerName, cntPubAccess, cleanUpContainer, expFP,
+                    expVP, excludeFP, getArtifactUploadType(), individualBlobs, archiveBlobs, ws);
 
-	    // Mark build unstable if no files are uploaded and the user
-	    // doesn't want the build not to fail in that case.
-	    if (filesUploaded == 0) {
-		listener.getLogger().println(
-			Messages.WAStoragePublisher_nofiles_uploaded());
-		if (!doNotFailIfArchivingReturnsNothing) {
-		    throw new IOException(Messages.WAStoragePublisher_nofiles_uploaded());
-		}
-	    } else {
-		AzureBlob zipArchiveBlob = null;
-		if (getArtifactUploadType() != UploadType.INDIVIDUAL) {
-		    zipArchiveBlob = archiveBlobs.get(0);
-		}
-		listener.getLogger().println(Messages.WAStoragePublisher_files_uploaded_count(filesUploaded));
+            // Mark build unstable if no files are uploaded and the user
+            // doesn't want the build not to fail in that case.
+            if (filesUploaded == 0) {
+                listener.getLogger().println(
+                        Messages.WAStoragePublisher_nofiles_uploaded());
+                if (!doNotFailIfArchivingReturnsNothing) {
+                    throw new IOException(Messages.WAStoragePublisher_nofiles_uploaded());
+                }
+            } else {
+                AzureBlob zipArchiveBlob = null;
+                if (getArtifactUploadType() != UploadType.INDIVIDUAL) {
+                    zipArchiveBlob = archiveBlobs.get(0);
+                }
+                listener.getLogger().println(Messages.WAStoragePublisher_files_uploaded_count(filesUploaded));
 
-		run.getActions().add(new AzureBlobAction(run, strAcc.getStorageAccName(),
-			expContainerName, individualBlobs, zipArchiveBlob, allowAnonymousAccess));
-	    }
-	} catch (Exception e) {
-	    e.printStackTrace(listener.error(Messages
-		    .WAStoragePublisher_uploaded_err(strAcc.getStorageAccName())));
-	    throw new IOException(Messages.WAStoragePublisher_uploaded_err(strAcc.getStorageAccName()));
-	}
+                run.getActions().add(new AzureBlobAction(run, strAcc.getStorageAccName(),
+                        expContainerName, individualBlobs, zipArchiveBlob, allowAnonymousAccess));
+            }
+        } catch (Exception e) {
+            e.printStackTrace(listener.error(Messages
+                    .WAStoragePublisher_uploaded_err(strAcc.getStorageAccName())));
+            throw new IOException(Messages.WAStoragePublisher_uploaded_err(strAcc.getStorageAccName()));
+        }
     }
 
     private boolean validateData(Run<?, ?> run,
-	    TaskListener listener, StorageAccountInfo storageAccount, String expContainerName) throws IOException, InterruptedException {
+            TaskListener listener, StorageAccountInfo storageAccount, String expContainerName) throws IOException, InterruptedException {
 
-	// No need to upload artifacts if build failed and the job is
-	// set to not upload on success.
-	if ((run.getResult() == Result.FAILURE || run.getResult() == Result.ABORTED) && uploadArtifactsOnlyIfSuccessful) {
-	    listener.getLogger().println(
-		    Messages.WAStoragePublisher_build_failed_err());
-	    return false;
-	}
+        // No need to upload artifacts if build failed and the job is
+        // set to not upload on success.
+        if ((run.getResult() == Result.FAILURE || run.getResult() == Result.ABORTED) && uploadArtifactsOnlyIfSuccessful) {
+            listener.getLogger().println(
+                    Messages.WAStoragePublisher_build_failed_err());
+            return false;
+        }
 
-	if (storageAccount == null) {
-	    listener.getLogger().println(
-		    Messages.WAStoragePublisher_storage_account_err());
-	    return false;
-	}
+        if (storageAccount == null) {
+            listener.getLogger().println(
+                    Messages.WAStoragePublisher_storage_account_err());
+            return false;
+        }
 
-	// Validate files path
-	if (Utils.isNullOrEmpty(filesPath)) {
-	    listener.getLogger().println(
-		    Messages.WAStoragePublisher_filepath_err());
-	    return false;
-	}
+        // Validate files path
+        if (Utils.isNullOrEmpty(filesPath)) {
+            listener.getLogger().println(
+                    Messages.WAStoragePublisher_filepath_err());
+            return false;
+        }
 
-	if (getArtifactUploadType() == UploadType.INVALID) {
-	    listener.getLogger().println(
-		    Messages.WAStoragePublisher_uploadtype_invalid());
-	    return false;
-	}
+        if (getArtifactUploadType() == UploadType.INVALID) {
+            listener.getLogger().println(
+                    Messages.WAStoragePublisher_uploadtype_invalid());
+            return false;
+        }
 
-	if (Utils.isNullOrEmpty(expContainerName)) {
-	    listener.getLogger().println("Container name is null or empty");
-	    return false;
-	}
+        if (Utils.isNullOrEmpty(expContainerName)) {
+            listener.getLogger().println("Container name is null or empty");
+            return false;
+        }
 
-	if (!Utils.validateContainerName(expContainerName)) {
-	    listener.getLogger().println("Container name contains invalid characters");
-	    return false;
-	}
+        if (!Utils.validateContainerName(expContainerName)) {
+            listener.getLogger().println("Container name contains invalid characters");
+            return false;
+        }
 
-	// Check if storage account credentials are valid
-	try {
-	    WAStorageClient.validateStorageAccount(storageAccount);
-	} catch (Exception e) {
-	    listener.getLogger().println(Messages.Client_SA_val_fail());
-	    listener.getLogger().println(
-		    "Storage Account name --->"
-		    + storageAccount.getStorageAccName() + "<----");
-	    listener.getLogger().println(
-		    "Blob end point url --->"
-		    + storageAccount.getBlobEndPointURL() + "<----");
-	    return false;
-	}
-	return true;
+        // Check if storage account credentials are valid
+        try {
+            WAStorageClient.validateStorageAccount(storageAccount);
+        } catch (Exception e) {
+            listener.getLogger().println(Messages.Client_SA_val_fail());
+            listener.getLogger().println(
+                    "Storage Account name --->"
+                    + storageAccount.getStorageAccName() + "<----");
+            listener.getLogger().println(
+                    "Blob end point url --->"
+                    + storageAccount.getBlobEndPointURL() + "<----");
+            return false;
+        }
+        return true;
     }
 
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
-	return doNotWaitForPreviousBuild ? BuildStepMonitor.NONE : BuildStepMonitor.STEP;
+        return doNotWaitForPreviousBuild ? BuildStepMonitor.NONE : BuildStepMonitor.STEP;
     }
 
     @Extension
     public static final class WAStorageDescriptor extends
-	    BuildStepDescriptor<Publisher> {
+            BuildStepDescriptor<Publisher> {
 
-	private final CopyOnWriteList<StorageAccountInfo> storageAccounts = new CopyOnWriteList<StorageAccountInfo>();
+        private final CopyOnWriteList<StorageAccountInfo> storageAccounts = new CopyOnWriteList<StorageAccountInfo>();
 
-	public WAStorageDescriptor() {
-	    super();
-	    load();
-	}
+        public WAStorageDescriptor() {
+            super();
+            load();
+        }
 
-	@Override
-	public boolean configure(StaplerRequest req, JSONObject formData)
-		throws FormException {
-	    storageAccounts.replaceBy(req.bindParametersToList(
-		    StorageAccountInfo.class, "was_"));
-	    save();
-	    return super.configure(req, formData);
-	}
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData)
+                throws FormException {
 
-	/**
-	 * Validates storage account details.
-	 *
-	 * @param storageAccountName
-	 * @param blobEndPointURL
-	 * @param storageAccountKey
-	 * @return
-	 * @throws IOException
-	 * @throws ServletException
-	 */
-	public FormValidation doCheckAccount(
-		@QueryParameter String was_storageAccName,
-		@QueryParameter String was_storageAccountKey,
-		@QueryParameter String was_blobEndPointURL) throws IOException,
-		ServletException {
+            storageAccounts.replaceBy(req.bindParametersToList(
+                    StorageAccountInfo.class, "was_"));
+            save();
+            return super.configure(req, formData);
+        }
 
-	    if (Utils.isNullOrEmpty(was_storageAccName)) {
-		return FormValidation.error(Messages
-			.WAStoragePublisher_storage_name_req());
-	    }
+        /**
+         * Validates storage account details.
+         *
+         * @param storageAccountName
+         * @param blobEndPointURL
+         * @param storageAccountKey
+         * @return
+         * @throws IOException
+         * @throws ServletException
+         */
+        public FormValidation doCheckAccount(
+                @QueryParameter String was_storageAccName,
+                @QueryParameter String was_storageAccountKey,
+                @QueryParameter String was_blobEndPointURL) throws IOException,
+                ServletException {
 
-	    if (Utils.isNullOrEmpty(was_storageAccountKey)) {
-		return FormValidation.error(Messages
-			.WAStoragePublisher_storage_key_req());
-	    }
+            if (Utils.isNullOrEmpty(was_storageAccName)) {
+                return FormValidation.error(Messages
+                        .WAStoragePublisher_storage_name_req());
+            }
 
-	    try {
-		// Get formatted blob end point URL.
-		was_blobEndPointURL = Utils.getBlobEP(was_blobEndPointURL);
-		StorageAccountInfo storageAccount = new StorageAccountInfo(was_storageAccName, was_storageAccountKey, was_blobEndPointURL);
-		WAStorageClient.validateStorageAccount(storageAccount);
-	    } catch (Exception e) {
-		return FormValidation.error("Error : " + e.getMessage());
-	    }
-	    return FormValidation.ok(Messages.WAStoragePublisher_SA_val());
-	}
+            if (Utils.isNullOrEmpty(was_storageAccountKey)) {
+                return FormValidation.error(Messages
+                        .WAStoragePublisher_storage_key_req());
+            }
 
-	/**
-	 * Checks for valid container name.
-	 *
-	 * @param val name of the container
-	 * @return FormValidation result
-	 * @throws IOException
-	 * @throws ServletException
-	 */
-	public FormValidation doCheckName(@QueryParameter String val)
-		throws IOException, ServletException {
-	    if (!Utils.isNullOrEmpty(val)) {
-		// Token resolution happens dynamically at runtime , so for
-		// basic validations
-		// if text contain tokens considering it as valid input.
-		if (Utils.containTokens(val)
-			|| Utils.validateContainerName(val)) {
-		    return FormValidation.ok();
-		} else {
-		    return FormValidation.error(Messages
-			    .WAStoragePublisher_container_name_invalid());
-		}
-	    } else {
-		return FormValidation.error(Messages
-			.WAStoragePublisher_container_name_req());
-	    }
-	}
+            try {
+                // Get formatted blob end point URL.
+                was_blobEndPointURL = Utils.getBlobEP(was_blobEndPointURL);
+                StorageAccountInfo storageAccount = new StorageAccountInfo(was_storageAccName, was_storageAccountKey, was_blobEndPointURL);
+                WAStorageClient.validateStorageAccount(storageAccount);
+            } catch (Exception e) {
+                return FormValidation.error("Error : " + e.getMessage());
+            }
+            return FormValidation.ok(Messages.WAStoragePublisher_SA_val());
+        }
 
-	public FormValidation doCheckPath(@QueryParameter String val) {
-	    if (Utils.isNullOrEmpty(val)) {
-		return FormValidation.error(Messages
-			.WAStoragePublisher_artifacts_req());
-	    }
-	    return FormValidation.ok();
-	}
+        /**
+         * Checks for valid container name.
+         *
+         * @param val name of the container
+         * @return FormValidation result
+         * @throws IOException
+         * @throws ServletException
+         */
+        public FormValidation doCheckName(@QueryParameter String val)
+                throws IOException, ServletException {
+            if (!Utils.isNullOrEmpty(val)) {
+                // Token resolution happens dynamically at runtime , so for
+                // basic validations
+                // if text contain tokens considering it as valid input.
+                if (Utils.containTokens(val)
+                        || Utils.validateContainerName(val)) {
+                    return FormValidation.ok();
+                } else {
+                    return FormValidation.error(Messages
+                            .WAStoragePublisher_container_name_invalid());
+                }
+            } else {
+                return FormValidation.error(Messages
+                        .WAStoragePublisher_container_name_req());
+            }
+        }
 
-	public FormValidation doCheckBlobName(@QueryParameter String val) {
-	    if (Utils.isNullOrEmpty(val)) {
-		return FormValidation.error(Messages
-			.AzureStorageBuilder_blobName_req());
-	    } else if (!Utils.validateBlobName(val)) {
-		return FormValidation.error(Messages
-			.AzureStorageBuilder_blobName_invalid());
-	    } else {
-		return FormValidation.ok();
-	    }
+        public FormValidation doCheckPath(@QueryParameter String val) {
+            if (Utils.isNullOrEmpty(val)) {
+                return FormValidation.error(Messages
+                        .WAStoragePublisher_artifacts_req());
+            }
+            return FormValidation.ok();
+        }
 
-	}
+        public FormValidation doCheckBlobName(@QueryParameter String val) {
+            if (Utils.isNullOrEmpty(val)) {
+                return FormValidation.error(Messages
+                        .AzureStorageBuilder_blobName_req());
+            } else if (!Utils.validateBlobName(val)) {
+                return FormValidation.error(Messages
+                        .AzureStorageBuilder_blobName_invalid());
+            } else {
+                return FormValidation.ok();
+            }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-	    return true;
-	}
+        }
 
-	@Override
-	public String getDisplayName() {
-	    return Messages.WAStoragePublisher_displayName();
-	}
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
 
-	public StorageAccountInfo[] getStorageAccounts() {
-	    return storageAccounts
-		    .toArray(new StorageAccountInfo[storageAccounts.size()]);
-	}
+        @Override
+        public String getDisplayName() {
+            return Messages.WAStoragePublisher_displayName();
+        }
 
-	public StorageAccountInfo getStorageAccount(String name) {
+        public StorageAccountInfo[] getStorageAccounts() {
+            return storageAccounts
+                    .toArray(new StorageAccountInfo[storageAccounts.size()]);
+        }
 
-	    if (name == null || (name.trim().length() == 0)) {
-		return null;
-	    }
+        public StorageAccountInfo getStorageAccount(String name) {
 
-	    StorageAccountInfo storageAccountInfo = null;
-	    StorageAccountInfo[] storageAccountList = getStorageAccounts();
+            if (name == null || (name.trim().length() == 0)) {
+                return null;
+            }
 
-	    if (storageAccountList != null) {
-		for (StorageAccountInfo sa : storageAccountList) {
-		    if (sa.getStorageAccName().equals(name)) {
-			storageAccountInfo = sa;
-			storageAccountInfo.setBlobEndPointURL(
-				Utils.getBlobEP(storageAccountInfo.getBlobEndPointURL()));
-			break;
-		    }
-		}
-	    }
-	    return storageAccountInfo;
-	}
+            StorageAccountInfo storageAccountInfo = null;
+            StorageAccountInfo[] storageAccountList = getStorageAccounts();
 
-	public String getDefaultBlobURL() {
-	    return Utils.getDefaultBlobURL();
-	}
+            if (storageAccountList != null) {
+                for (StorageAccountInfo sa : storageAccountList) {
+                    if (sa.getStorageAccName().equals(name)) {
+                        storageAccountInfo = sa;
+                        storageAccountInfo.setBlobEndPointURL(
+                                Utils.getBlobEP(storageAccountInfo.getBlobEndPointURL()));
+                        break;
+                    }
+                }
+            }
+            return storageAccountInfo;
+        }
 
-	public ListBoxModel doFillStorageAccNameItems() {
-	    ListBoxModel m = new ListBoxModel();
-	    StorageAccountInfo[] StorageAccounts = getStorageAccounts();
+        public String getDefaultBlobURL() {
+            return Utils.getDefaultBlobURL();
+        }
 
-	    if (StorageAccounts != null) {
-		for (StorageAccountInfo storageAccount : StorageAccounts) {
-		    m.add(storageAccount.getStorageAccName());
-		}
-	    }
-	    return m;
-	}
+        public ListBoxModel doFillStorageAccNameItems() {
+            ListBoxModel m = new ListBoxModel();
+            StorageAccountInfo[] StorageAccounts = getStorageAccounts();
+
+            if (StorageAccounts != null) {
+                for (StorageAccountInfo storageAccount : StorageAccounts) {
+                    m.add(storageAccount.getStorageAccName());
+                }
+            }
+            return m;
+        }
+
+        public ListBoxModel doFillStorageCredentialIdItems(@AncestorInPath Item owner) {
+
+            ListBoxModel m = new StandardListBoxModel().withAll(CredentialsProvider.lookupCredentials(AzureCredentials.class, owner, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()));
+            return m;
+        }
+
+        @Restricted(NoExternalUse.class)
+        public List<String> getStorageCredentials() {
+            Item owner = null;
+            ListBoxModel allCreds = new StandardListBoxModel().withAll(CredentialsProvider.lookupCredentials(AzureCredentials.class, owner, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()));
+            ArrayList<Object> res = new ArrayList<Object>();
+            List<String> allStorageCred = new ArrayList<String>();
+            for (int i = 0; i < allCreds.size(); i++) {
+                res.add(allCreds.get(i));
+                String eachStorageCredential = res.get(i).toString();
+                String eachStorageAccount = eachStorageCredential.substring(0, eachStorageCredential.indexOf('='));
+
+                allStorageCred.add(eachStorageAccount);
+
+            }
+            return allStorageCred;
+        }
+
     }
+
 }

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentials.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentials.java
@@ -1,0 +1,171 @@
+/*
+ Copyright 2016 Microsoft, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package com.microsoftopentechnologies.windowsazurestorage.helper;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.microsoftopentechnologies.windowsazurestorage.Messages;
+import com.microsoftopentechnologies.windowsazurestorage.Messages;
+import com.microsoftopentechnologies.windowsazurestorage.WAStorageClient;
+import com.microsoftopentechnologies.windowsazurestorage.WAStorageClient;
+import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
+import com.microsoftopentechnologies.windowsazurestorage.exceptions.*;
+import hudson.Extension;
+import hudson.security.ACL;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
+import java.util.Collections;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ *
+ * @author arroyc
+ */
+public class AzureCredentials extends BaseStandardCredentials {
+
+    public static class StorageAccountCredential implements java.io.Serializable {
+
+        public final String storageAccountName;
+        public final Secret storageAccountKey;
+        public final String blobEndpointURL;
+
+        public StorageAccountCredential(
+                String storageAccountName,
+                String storageKey,
+                String endpointURL) {
+            this.storageAccountName = storageAccountName;
+            this.storageAccountKey = Secret.fromString(storageKey);
+            this.blobEndpointURL = StringUtils.isBlank(endpointURL)
+                    ? Constants.DEFAULT_ENDPOINT_URL
+                    : endpointURL;
+        }
+
+        public StorageAccountCredential() {
+            this.storageAccountName = "";
+            this.storageAccountKey = Secret.fromString("");
+            this.blobEndpointURL = Constants.DEFAULT_ENDPOINT_URL;
+        }
+
+        public boolean isValidStorageCredential() throws WAStorageException {
+            if (StringUtils.isBlank(storageAccountName)) {
+                throw new WAStorageException("Error: Storage Account Name is missing");
+            }
+
+            if (StringUtils.isBlank(storageAccountKey.getPlainText())) {
+                throw new WAStorageException("Error: Storage Account Key is missing");
+            }
+
+            if (StringUtils.isBlank(blobEndpointURL)) {
+                throw new WAStorageException("Error: bloblEndpointURL is invalid or missing");
+            }
+
+            return true;
+        }
+
+        public String getStorageAccountName() {
+            return storageAccountName;
+        }
+
+        public String getstorageAccountKey() {
+            return storageAccountKey.getPlainText();
+        }
+
+        public String getEndpointURL() {
+            return blobEndpointURL;
+        }
+
+    }
+
+    public final StorageAccountCredential storageData;
+
+    @DataBoundConstructor
+    public AzureCredentials(
+            CredentialsScope scope,
+            String id,
+            String description,
+            String storageAccountName,
+            String storageKey,
+            String blobEndpointURL
+    ) {
+        super(scope, id, description);
+        storageData = new StorageAccountCredential(storageAccountName, storageKey, blobEndpointURL);
+
+    }
+
+    public static AzureCredentials.StorageAccountCredential getStorageAccountCredential(final String storageCredentialId) {
+        AzureCredentials creds = CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(AzureCredentials.class, Jenkins.getInstance(), ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+                CredentialsMatchers.withId(storageCredentialId));
+        if (creds == null) {
+            return new AzureCredentials.StorageAccountCredential();
+        }
+        return creds.storageData;
+    }
+
+    public String getStorageAccountName() {
+        return storageData.storageAccountName;
+    }
+
+    public String getstorageAccountKey() {
+        return storageData.storageAccountKey.getPlainText();
+    }
+
+    public String getEndpointURL() {
+        return storageData.blobEndpointURL;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Microsoft Azure Storage";
+        }
+
+        public String getDefaultBlobURL() {
+            return Constants.DEFAULT_ENDPOINT_URL;
+        }
+
+        public FormValidation doVerifyConfiguration(
+                @QueryParameter String storageAccountName,
+                @QueryParameter String storageKey,
+                @QueryParameter String blobEndpointURL) {
+
+            try {
+                StorageAccountInfo storageAccount = new StorageAccountInfo(storageAccountName, storageKey, blobEndpointURL);
+                WAStorageClient.validateStorageAccount(storageAccount);
+                AzureCredentials.StorageAccountCredential storageCreds = new AzureCredentials.StorageAccountCredential(storageAccountName, storageKey, blobEndpointURL);
+            } catch (Exception e) {
+                return FormValidation.error(e.getMessage());
+            }
+
+            return FormValidation.ok(Messages.WAStoragePublisher_SA_val());
+        }
+
+    }
+
+    public static StorageAccountInfo convertToStorageAccountInfo(StorageAccountCredential storageCreds) {
+        StorageAccountInfo storageAccount = new StorageAccountInfo(storageCreds.getStorageAccountName(),
+                storageCreds.getstorageAccountKey(), storageCreds.getEndpointURL());
+        return storageAccount;
+    }
+
+}

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
@@ -1,0 +1,16 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.microsoftopentechnologies.windowsazurestorage.helper;
+
+/**
+ *
+ * @author arroyc
+ */
+public class Constants {
+    
+    public static String DEFAULT_ENDPOINT_URL = "http://blob.core.windows.net/";
+    
+}

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
@@ -10,7 +10,20 @@ package com.microsoftopentechnologies.windowsazurestorage.helper;
  * @author arroyc
  */
 public class Constants {
-    
-    public static String DEFAULT_ENDPOINT_URL = "http://blob.core.windows.net/";
-    
+
+    /* Regular expression for valid container name */
+    public static final String VAL_CNT_NAME = "^(([a-z\\d]((-(?=[a-z\\d]))|([a-z\\d])){2,62}))$";
+
+    /* Regular expression to match tokens in the format of $TOKEN or ${TOKEN} */
+    public static final String TOKEN_FORMAT = "\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_]+\\})";
+
+    public static final String DEF_BLOB_URL = "http://blob.core.windows.net/";
+    public static final String FWD_SLASH = "/";
+    public static final String HTTP_PRT = "http://";
+    // http Protocol separator
+    public static final String PRT_SEP = "://";
+    public static final String LEGACY_STORAGE_CONFIG_FILE = "com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher.xml";
+    public static final String HASH_TYPE = "MD5";
+    public static final String CREDENTIALS_AJAX_URI = "/descriptor/com.cloudbees.plugins.credentials.CredentialsSelectHelper/resolver/com.cloudbees.plugins.credentials.CredentialsSelectHelper$SystemContextResolver/provider/com.cloudbees.plugins.credentials.SystemCredentialsProvider$ProviderImpl/context/jenkins/dialog";
+
 }

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialMigration.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialMigration.java
@@ -1,0 +1,164 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.microsoftopentechnologies.windowsazurestorage.helper;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
+import hudson.security.ACL;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.logging.Logger;
+import java.util.List;
+import java.util.logging.Level;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import jenkins.model.Jenkins;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.apache.commons.io.FileUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ *
+ * @author arroyc
+ */
+public class CredentialMigration {
+    private static final Logger LOGGER = Logger.getLogger(CredentialMigration.class.getName());
+    
+    private static List<StorageAccountInfo> getOldStorageConfig(File inputFile) throws SAXException, IOException, ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        // Load the legacy storage config XML document, parse it and return a list of storage accounts
+        Document document = builder.parse(inputFile);
+
+        List<StorageAccountInfo> storages = new ArrayList<StorageAccountInfo>();
+
+        NodeList nodeList = document.getElementsByTagName("com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo");
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            Node node = nodeList.item(i);
+
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                Element elem = (Element) node;
+
+                // Get the value of all sub-elements.
+                String accName = elem.getElementsByTagName("storageAccName")
+                        .item(0).getChildNodes().item(0).getNodeValue();
+
+                String accKey = elem.getElementsByTagName("storageAccountKey").item(0)
+                        .getChildNodes().item(0).getNodeValue();
+
+                String blobURL = elem.getElementsByTagName("blobEndPointURL").item(0)
+                        .getChildNodes().item(0).getNodeValue();
+
+                storages.add(new StorageAccountInfo(accName, accKey, blobURL));
+            }
+        }
+
+        return storages;
+
+    }
+
+    private static File backupFile(String sourceFile) throws IOException {
+        String backupFile = sourceFile + ".backup";
+        LOGGER.log(Level.INFO, sourceFile+".backup has been created for backup.");
+        File backUp = new File(backupFile);
+        FileUtils.copyFile(new File(sourceFile), backUp);
+        return backUp;
+    }
+
+    /**
+     *
+     * Take the legacy local storage credential configuration and create an
+     * equivalent global credential in Jenkins Credential Store
+     *
+     */
+    private static void removeFile(String sourceFile) throws IOException {
+        File file = new File(sourceFile);
+
+        if (file.delete()) {
+            LOGGER.log(Level.INFO, file.getName() + " is deleted!");
+        } else {
+            LOGGER.log(Level.WARNING, file.getName() + "deletion is failed.");
+        }
+    }
+
+    public static void upgradeStorageConfig() throws Exception {
+        
+        File sourceFile = new File(Utils.getWorkDirectory(), Constants.LEGACY_STORAGE_CONFIG_FILE);
+        try {
+            //check if we need to upgrade (i.e. if we have prior version of 0.3.2 storage plugin)
+            if (!sourceFile.exists()) {
+                return;
+            }
+
+            LOGGER.log(Level.INFO, sourceFile + " exists, upgrade will start now...");
+
+            File backUp = backupFile(sourceFile.getCanonicalPath());
+            List<StorageAccountInfo> oldStorages = getOldStorageConfig(sourceFile);
+
+            if (oldStorages.size() > 0) {
+                for (StorageAccountInfo sa : oldStorages) {
+                    String storageAccount = sa.getStorageAccName();
+                    String storageAccountKey = sa.getStorageAccountKey();
+                    String storageBlobURL = sa.getBlobEndPointURL();
+
+                    AzureCredentials.StorageAccountCredential u = new AzureCredentials.StorageAccountCredential(storageAccount, storageAccountKey, storageBlobURL);
+                    AzureCredentials cred = CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(AzureCredentials.class, Jenkins.getInstance(), ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+                            CredentialsMatchers.withId(u.getId()));
+                    if (cred != null) {
+                        return;
+                    }
+
+                    LOGGER.log(Level.INFO, "Moving Storage Account names and their keys to credential store, a creddential Id will be created for each pair of account name and key.");
+
+                    // no matching, so make our own.
+                    AzureCredentials tempCred = new AzureCredentials(CredentialsScope.GLOBAL, Utils.getMD5(storageAccount.concat(storageAccountKey)), "credential for " + storageAccount, storageAccount, storageAccountKey, storageBlobURL);
+                    final SecurityContext securityContext = ACL.impersonate(ACL.SYSTEM);
+
+                    try {
+                        CredentialsStore s = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+                        try {
+                            s.addCredentials(Domain.global(), tempCred);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+
+                    } finally {
+
+                        SecurityContextHolder.setContext(securityContext);
+
+                    } // end finally
+
+                } //end for
+
+            } // end if
+            
+            LOGGER.log(Level.INFO, "Migrated successfully, deleting legacy config files...");
+            removeFile(sourceFile.getCanonicalPath());
+            removeFile(backUp.getCanonicalPath());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return;
+
+    }
+
+}

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -16,20 +16,9 @@
 package com.microsoftopentechnologies.windowsazurestorage.helper;
 
 import java.util.Locale;
+import jenkins.model.Jenkins;
 
 public class Utils {
-
-    /* Regular expression for valid container name */
-    public static final String VAL_CNT_NAME = "^(([a-z\\d]((-(?=[a-z\\d]))|([a-z\\d])){2,62}))$";
-
-    /* Regular expression to match tokens in the format of $TOKEN or ${TOKEN} */
-    public static final String TOKEN_FORMAT = "\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_]+\\})";
-
-    public static final String DEF_BLOB_URL = "http://blob.core.windows.net/";
-    public static final String FWD_SLASH = "/";
-    public static final String HTTP_PRT = "http://";
-    // http Protocol separator
-    public static final String PRT_SEP = "://";
 
     /**
      * Checks for validity of container name after converting the input into
@@ -44,18 +33,18 @@ public class Utils {
      * @return true if container name is valid else returns false
      */
     public static boolean validateContainerName(final String containerName) {
-	if (containerName != null) {
-	    String lcContainerName = containerName.trim().toLowerCase(
-		    Locale.ENGLISH);
-	    if (lcContainerName.matches(VAL_CNT_NAME)) {
-		return true;
-	    }
-	}
-	return false;
+        if (containerName != null) {
+            String lcContainerName = containerName.trim().toLowerCase(
+                    Locale.ENGLISH);
+            if (lcContainerName.matches(Constants.VAL_CNT_NAME)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean validateBlobName(final String blobName) {
-	return blobName != null && (blobName.length() > 0 && blobName.length() <= 1024);
+        return blobName != null && (blobName.length() > 0 && blobName.length() <= 1024);
     }
 
     /**
@@ -65,7 +54,7 @@ public class Utils {
      * @return true if null or empty string
      */
     public static boolean isNullOrEmpty(final String name) {
-	return name == null || name.matches("\\s*");
+        return name == null || name.matches("\\s*");
     }
 
     /**
@@ -76,10 +65,10 @@ public class Utils {
      * @return true if tokens exist in input string
      */
     public static boolean containTokens(String text) {
-	if (isNullOrEmpty(text)) {
-	    return false;
-	}
-	return text.matches(TOKEN_FORMAT);
+        if (isNullOrEmpty(text)) {
+            return false;
+        }
+        return text.matches(Constants.TOKEN_FORMAT);
     }
 
     /**
@@ -92,24 +81,24 @@ public class Utils {
      */
     public static String getBlobEP(String blobURL) {
 
-	if (isNullOrEmpty(blobURL)) {
-	    return DEF_BLOB_URL;
-	}
+        if (isNullOrEmpty(blobURL)) {
+            return Constants.DEF_BLOB_URL;
+        }
 
-	// Append forward slash
-	if (!blobURL.endsWith(FWD_SLASH)) {
-	    blobURL = blobURL.concat(FWD_SLASH);
-	}
+        // Append forward slash
+        if (!blobURL.endsWith(Constants.FWD_SLASH)) {
+            blobURL = blobURL.concat(Constants.FWD_SLASH);
+        }
 
-	// prepend http protocol if missing
-	if (!blobURL.contains(PRT_SEP)) {
-	    blobURL = new StringBuilder()
-		    .append(HTTP_PRT)
-		    .append(blobURL)
-		    .toString();
-	}
+        // prepend http protocol if missing
+        if (!blobURL.contains(Constants.PRT_SEP)) {
+            blobURL = new StringBuilder()
+                    .append(Constants.HTTP_PRT)
+                    .append(blobURL)
+                    .toString();
+        }
 
-	return blobURL;
+        return blobURL;
     }
 
     /**
@@ -118,6 +107,31 @@ public class Utils {
      * @return
      */
     public static String getDefaultBlobURL() {
-	return DEF_BLOB_URL;
+        return Constants.DEF_BLOB_URL;
     }
+
+    /**
+     * Returns md5 hash in string format for a given string
+     *
+     * @return
+     */
+    public static String getMD5(String plainText) {
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance(Constants.HASH_TYPE);
+            byte[] array = md.digest(plainText.getBytes());
+            StringBuffer sb = new StringBuffer();
+            for (int i = 0; i < array.length; ++i) {
+                sb.append(Integer.toHexString((array[i] & 0xFF) | 0x100).substring(1, 3));
+            }
+            return sb.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static String getWorkDirectory() {
+        return Jenkins.getInstance().root.getAbsolutePath();
+    }
+
 }

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
@@ -1,10 +1,5 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:ab="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<!--
-    <f:entry title="${%storageAccountName_title}" field="storageAccName" help="/plugin/windows-azure-storage/help-builderSelectstorageaccount.html">
-        <f:select  />
-    </f:entry>
--->    
     <f:entry title="${%Storage_Credentials}" field="storageCredentialId" help="/plugin/windows-azure-storage/help-storagecredential.html"> 
         <ab:select expressionAllowed="false"/>
     </f:entry> 

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
@@ -1,9 +1,13 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:ab="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<!--
     <f:entry title="${%storageAccountName_title}" field="storageAccName" help="/plugin/windows-azure-storage/help-builderSelectstorageaccount.html">
         <f:select  />
     </f:entry>
+-->    
+    <f:entry title="${%Storage_Credentials}" field="storageCredentialId" help="/plugin/windows-azure-storage/help-storagecredential.html"> 
+        <ab:select expressionAllowed="false"/>
+    </f:entry> 
 
     <f:section title="${%downloadType_title}">
         <f:radioBlock name="downloadType" title="Download from container" value="container" checked="${instance.getDonwloadType() == null || instance.getDownloadType() == 'container'}">

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/config.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-   
-	<f:entry title="${%storageAccountName_title}" field="storageAccName" help="/plugin/windows-azure-storage/help-selectstorageaccount.html">
-		<f:select />
-	</f:entry>
-  
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+        <f:entry title="${%Storage_Credentials}" field="storageCredentialId" help="/plugin/windows-azure-storage/help-storagecredential.html"> 
+                <c:select expressionAllowed="false"/>
+        </f:entry> 
+        
 	<f:entry title="${%containerName_title}" field="containerName" help="/plugin/windows-azure-storage/help-containerName.html">
 		<f:textbox  checkUrl="'${rootURL}/publisher/WAStoragePublisher/checkName?val='+encodeURIComponent(this.value)" />
 	</f:entry>

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.jelly
@@ -1,11 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:sf="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
     <f:section title="${%WindowsAzureStorage_title}" id="windows-azure-storage">
         <f:entry title="${%entry_title}" >
-            <f:entry var="storageAccount" items="${descriptor.storageAccounts}" noAddButton="false" minimum="1">
-                <table width="100%">
-                    <f:entry title="" field="storageCredentialId" help="/plugin/windows-azure-storage/help-storageaccounts.html"> 
+            <f:entry var="storageAccount" items="${descriptor.storageAccounts}" noAddButton="true" minimum="1">
+                <table width="102%">
+                    
+                    <f:entry field="storageCredentialId" help="/plugin/windows-azure-storage/help-storageaccounts.html"> 
                         <div style="display: none; !important">
                             <sf:select class="display: none !important" expressionAllowed="false" />
                         </div>
@@ -23,9 +23,10 @@
                     </j:forEach>
                 </div>
                 <div align="center"> 
-                    <input type="button" class="yui-button yui-push-button" value="Add Storage Accounts" onclick="window.credentials.add()" /> 
+                    <j:set var="credsAjaxURI" value="${instance.getAjaxURI()}"/>
+                    <input type="button" class="yui-button" value="Add Storage Accounts" onclick="window.credentials.add('${credsAjaxURI}')" /> 
                     <p>
-                        <a href="credential-store/domain/_/">Manage Storage Accounts in Credential Store</a>
+                        <a href="credentials/store/system/domain/_/" target="_blank">Manage Storage Accounts in Credential Store</a>
                     </p>
                 </div>
             </f:entry> 	

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.jelly
@@ -1,39 +1,34 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:sf="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-  <f:section title="${%WindowsAzureStorage_title}" id="windows-azure-storage">
-  	<f:entry title="${%entry_title}" >
-  		<f:repeatable var="storageAccount" items="${descriptor.storageAccounts}" noAddButton="true" minimum="1">
-  			<table width="100%">
-  	   			<f:entry title="${%rep_storageAccountName}" help="/plugin/windows-azure-storage/help-storageAccountName.html">
-    				<f:textbox name="was_storageAccName" value="${storageAccount.storageAccName}" />
-  				</f:entry>
-  			
-  				<f:entry title="${%rep_storageAccountKey}" help="/plugin/windows-azure-storage/help-storageAccountKey.html">
-    				   <f:password name="was_storageAccountKey" value="${storageAccount.storageAccountKey}" />
-  				</f:entry>
-  			
-  				<f:entry title="${%rep_blobEndPointURL}" help="/plugin/windows-azure-storage/help-blobEndPointURL.html">
-  					<f:textbox name="was_blobEndPointURL" value="${storageAccount.blobEndPointURL}" 
-    						default="${descriptor.getDefaultBlobURL()}" />
-  				</f:entry>
-  				
-  			    <f:entry title="">
-  			    	<div align="right">
-  			    	<f:validateButton
-   						title="${%rep_val_btn}" progress="${%rep_val_btn_msg}"
-   						method="checkAccount" with="was_storageAccName,was_storageAccountKey,was_blobEndPointURL" />
-  			    	</div>
-  			    </f:entry>
-  				<f:entry title="">
-  					<div align="left">
-  						<input type="button" value="${%rep_del_btn}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
-  						<input type="button" value="${%rep_addmore_btn}" class="repeatable-add show-if-last" />
-              		</div>
-  			
-  				</f:entry>      	
-      		</table>
-  		</f:repeatable> 	
-  	</f:entry>	
-  </f:section>
+    <f:section title="${%WindowsAzureStorage_title}" id="windows-azure-storage">
+        <f:entry title="${%entry_title}" >
+            <f:entry var="storageAccount" items="${descriptor.storageAccounts}" noAddButton="false" minimum="1">
+                <table width="100%">
+                    <f:entry title="" field="storageCredentialId" help="/plugin/windows-azure-storage/help-storageaccounts.html"> 
+                        <div style="display: none; !important">
+                            <sf:select class="display: none !important" expressionAllowed="false" />
+                        </div>
+                    </f:entry> 
+                    <j:set var="storagePublisher" value="${app.getDescriptorByName('com.microsoftopentechnologies.windowsazurestorage.WaStoragePublisher.WAStorageDescriptor')}"/>
+                    <j:set var="storageCreds" value="${instance.getStorageCredentials()}"/>
+                </table>
+                <div align="left" style="font-size:110%">
+                    <j:forEach var="storageCred" items="${storageCreds}">
+                        <ul style="list-style-type: none;">
+                            <li>
+                                <label>${storageCred}</label>
+                            </li>
+                        </ul>                
+                    </j:forEach>
+                </div>
+                <div align="center"> 
+                    <input type="button" class="yui-button yui-push-button" value="Add Storage Accounts" onclick="window.credentials.add()" /> 
+                    <p>
+                        <a href="credential-store/domain/_/">Manage Storage Accounts in Credential Store</a>
+                    </p>
+                </div>
+            </f:entry> 	
+        </f:entry>	
+    </f:section>
 </j:jelly>

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.properties
@@ -1,9 +1,3 @@
 WindowsAzureStorage_title=Microsoft Azure Storage Account Configuration
-entry_title=Storage Account Details
-rep_storageAccountName=Storage account name
-rep_storageAccountKey=Storage account key
-rep_blobEndPointURL=Blob service endpoint URL
-rep_val_btn=Validate storage credentials
-rep_val_btn_msg=Validation in progress...
-rep_del_btn=Delete
-rep_addmore_btn=Add more storage accounts
+entry_title=Storage Account in the System (Storage Account names) 
+Storage_Credentials=Storage Credentials

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.properties
@@ -1,3 +1,6 @@
 WindowsAzureStorage_title=Microsoft Azure Storage Account Configuration
 entry_title=Storage Account in the System (Storage Account names) 
-Storage_Credentials=Storage Credentials
+rep_val_btn=Validate storage credentials
+rep_val_btn_msg=Validation in progress...
+rep_del_btn=Delete
+rep_addmore_btn=Add more storage accounts

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentials/credentials.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentials/credentials.jelly
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+    <j:set var="uniqueId" value="${h.generateId()}" />
+    <f:entry title="${%Storage Account Name}" field="storageAccountName" help="/plugin/windows-azure-storage/help-storageAccountName.html">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Storage Account Key}" field="storageKey" help="/plugin/windows-azure-storage/help-storageAccountKey.html">
+      <f:password />
+    </f:entry>
+    <f:entry title="${%Blob EndPoint URL}" field="blobEndpointURL" help="/plugin/windows-azure-storage/help-blobEndPointURL.html">
+      <f:textbox default="${descriptor.getDefaultBlobURL()}" />
+    </f:entry>
+    <st:include page="id-and-description" class="${descriptor.clazz}"/>
+    <f:validateButton title="${%Verify Configuration}" progress="${%Verifying}" method="verifyConfiguration"
+          with="storageAccountName,storageKey,blobEndpointURL" />
+</j:jelly>

--- a/src/main/resources/global.properties
+++ b/src/main/resources/global.properties
@@ -1,0 +1,9 @@
+WindowsAzureStorage_title=Microsoft Azure Storage Account Configuration
+entry_title=Storage Account Details
+rep_storageAccountName=Storage account name
+rep_storageAccountKey=Storage account key
+rep_blobEndPointURL=Blob service endpoint URL
+rep_val_btn=Validate storage credentials
+rep_val_btn_msg=Validation in progress...
+rep_del_btn=Delete
+rep_addmore_btn=Add more storage accounts

--- a/src/main/webapp/help-storageaccounts.html
+++ b/src/main/webapp/help-storageaccounts.html
@@ -1,0 +1,7 @@
+<div>
+The list of storage accounts configured within the Jenkins Master
+<br />
+Unique ids of each storage accounts are followed by the storage account names in brackets
+<br />
+
+</div>

--- a/src/main/webapp/help-storageaccounts.html
+++ b/src/main/webapp/help-storageaccounts.html
@@ -3,5 +3,5 @@ The list of storage accounts configured within the Jenkins Master
 <br />
 Unique ids of each storage accounts are followed by the storage account names in brackets
 <br />
-
+Refresh the page after you have added a new storage account.
 </div>

--- a/src/main/webapp/help-storagecredential.html
+++ b/src/main/webapp/help-storagecredential.html
@@ -1,0 +1,7 @@
+<div>
+The credentials for the storage account
+<br />
+The storage account should exist.
+<br />
+The key is one of the two keys (primary or secondary) attached with the given storage account.
+</div>

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import junit.framework.TestCase;
 
-
+import com.microsoftopentechnologies.windowsazurestorage.helper.Constants;
 import com.microsoftopentechnologies.windowsazurestorage.helper.Utils; 
 
 public class WindowsAzureStorageTest extends TestCase {
@@ -58,9 +58,9 @@ public class WindowsAzureStorageTest extends TestCase {
 	@Test
 	public void testGetBlobEPReturnsDefaultURL() throws Exception {
 		// return default blob host given null URL
-		assertEquals(Utils.DEF_BLOB_URL, Utils.getBlobEP(null));
+		assertEquals(Constants.DEF_BLOB_URL, Utils.getBlobEP(null));
 		// return default blob host given the default blob URL
-		assertEquals(Utils.DEF_BLOB_URL, Utils.getBlobEP(Utils.DEF_BLOB_URL));
+		assertEquals(Constants.DEF_BLOB_URL, Utils.getBlobEP(Constants.DEF_BLOB_URL));
 	}
 
 	@Test


### PR DESCRIPTION
Following are the changes:
1. Moved storage account config to Jenkins credential store which is more secure the original xml file  for storage config.
2. Upgrading plugin to 0.3.3 or future from an old version won't break any existing jobs.
3.  Storage Accounts can be added to credential store via credentials page from Jenkins dashboard, system configuration page as previous and job configuration page (new).
