### PR TITLE
fix incorrect endpoint for Azure China and other non-Global Azure env…

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
@@ -73,7 +73,7 @@ public class WAStorageClient {
 
     /**
      * This method validates Storage Account credentials by checking for a dummy
-     * conatiner existence.
+     * container existence.
      *
      * @param storageAccount
      * @return true if valid
@@ -123,9 +123,10 @@ public class WAStorageClient {
 	if (Utils.isNullOrEmpty(blobURL) || blobURL.equals(Constants.DEF_BLOB_URL)) {
 	    cloudStorageAccount = new CloudStorageAccount(credentials);
 	} else {
-	    cloudStorageAccount = new CloudStorageAccount(credentials, new URI(
-		    blobURL), new URI(getCustomURI(accName, QUEUE, blobURL)),
-		    new URI(getCustomURI(accName, TABLE, blobURL)));
+		String endpointSuffix = getEndpointSuffix(blobURL);
+		if(Utils.isNullOrEmpty(endpointSuffix))
+			throw new URISyntaxException(blobURL,"The blob endpoint is not correct!");
+		cloudStorageAccount = new CloudStorageAccount(credentials, false, endpointSuffix);
 	}
 
 	serviceClient = cloudStorageAccount.createCloudBlobClient();
@@ -170,7 +171,6 @@ public class WAStorageClient {
      */
     private static String getCustomURI(String storageAccountName, String type,
 	    String blobURL) {
-
 	if (QUEUE.equalsIgnoreCase(type)) {
 	    return blobURL.replace(storageAccountName + "." + BLOB,
 		    storageAccountName + "." + type);
@@ -180,6 +180,22 @@ public class WAStorageClient {
 	} else {
 	    return null;
 	}
+    }
+    
+    /**
+     * Returns suffix for blob endpoint.
+     *
+     * @param blob endpoint
+     * @return the endpoint suffix
+     */
+    private static String getEndpointSuffix(String blobURL)
+    {
+    	int endSuffixStartIndex = blobURL.toLowerCase().indexOf(Utils.BLOB_ENDPOINT_ENDSUFFIX_KEYWORD);
+    	if(endSuffixStartIndex < 0) {
+    		return null;
+    	} else {
+    		return blobURL.substring(endSuffixStartIndex);
+    	}
     }
 
     /**

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -20,6 +20,19 @@ import jenkins.model.Jenkins;
 
 public class Utils {
 
+    /* Regular expression for valid container name */
+    public static final String VAL_CNT_NAME = "^(([a-z\\d]((-(?=[a-z\\d]))|([a-z\\d])){2,62}))$";
+
+    /* Regular expression to match tokens in the format of $TOKEN or ${TOKEN} */
+    public static final String TOKEN_FORMAT = "\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_]+\\})";
+
+    public static final String DEF_BLOB_URL = "http://blob.core.windows.net/";
+    public static final String BLOB_ENDPOINT_ENDSUFFIX_KEYWORD = "core";
+    public static final String FWD_SLASH = "/";
+    public static final String HTTP_PRT = "http://";
+    // http Protocol separator
+    public static final String PRT_SEP = "://";
+
     /**
      * Checks for validity of container name after converting the input into
      * lowercase. Rules for container name 1.Container names must start with a

--- a/src/main/webapp/help-blobEndPointURL.html
+++ b/src/main/webapp/help-blobEndPointURL.html
@@ -1,5 +1,8 @@
 <div>
 	Leave this one to the default value or blank if you are using the public Microsoft Azure cloud.
 	If you are using a private or other Azure cloud service, enter the Blob service endpoint URL for that cloud.<br />
-	You can get this information from the Azure portal.
+	Here is a list of commmonly used values: <br />
+	Azure China: http://blob.core.chinacloudapi.cn <br />
+	Azure Germany Goverment: http://core.cloudapi.de <br />
+	Azure US Government: http://core.usgovcloudapi.net <br />
 </div>


### PR DESCRIPTION
For non-global azure enviornments, when verifiying storage account, it used contructor CloudStorageAccount(StorageCredentials credentials, URI blobendpoint, URI queueEndpoint, URI tableEndpoint), this requires user input complete blob uri(including account name) which is inconsistent with setting for global azure which users just need to input blob endpoint(without account name). 
So update to use another contructor of cloudstorageaccount, which use suffix, so users just need to provide blob endpoint like global azure.
Also update help document to list blob endpoints for different environments.