### PR TITLE
Make sure the file streams are closed after download or upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .classpath
 .project
 .settings
+
+*.idea
+*.iml


### PR DESCRIPTION
- While computing the file hash and size we weren't explicitly closing the stream.
- Changed the code around stream to look nicer (using try(resource acquisition){} idiom instead of try{}finally{ release resource} )
Before merging we need to verify that #49 is actually fixed 