### PR TITLE
resolve issue #42 

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -177,6 +177,7 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
 
             final String expProjectName = Util.replaceMacro(projectName, envVars);
             final AzureStorageBuilderContext azureStorageBuilderContext = new AzureStorageBuilderContext(launcher, run, listener);
+            azureStorageBuilderContext.setWorkspace(workspace);
 
             // Resolve include patterns
             String expIncludePattern = Util.replaceMacro(includeFilesPattern, envVars);

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilderContext.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilderContext.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Microsoft Corporation
+ *   <p/>
+ *  All rights reserved.
+ *   <p/>
+ *  MIT License
+ *   <p/>
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ *  documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ *  to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *  <p/>
+ *  The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ *  the Software.
+ *   <p/>
+ *  THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ *  THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package com.microsoftopentechnologies.windowsazurestorage;
+
+import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
+import com.microsoftopentechnologies.windowsazurestorage.helper.Utils;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
+
+public class AzureStorageBuilderContext {
+    private Run<?, ?> run;
+    Launcher launcher;
+    TaskListener listener;
+
+    FilePath workspace;
+    String includeFilesPattern;
+    String excludeFilesPattern;
+    StorageAccountInfo storageAccountInfo;
+    String containerName;
+    String downloadDirLoc;
+    boolean flattenDirectories;
+    boolean deleteFromAzureAfterDownload;
+
+    public AzureStorageBuilderContext(final Launcher launcher, final Run<?, ?> run, final TaskListener taskListener){
+        this.launcher = launcher;
+        this.run = run;
+        this.listener = taskListener;
+    }
+
+    public FilePath getWorkspacePath(){
+        return new FilePath(launcher.getChannel(), workspace.getRemote());
+    }
+
+    public FilePath getDownloadDir() {
+        FilePath downloadDir = getWorkspacePath();
+        try {
+            if (!Utils.isNullOrEmpty(downloadDirLoc)) {
+                final EnvVars envVars = run.getEnvironment(listener);
+                downloadDir = new FilePath(getWorkspacePath(), Util.replaceMacro(downloadDirLoc, envVars));
+            }
+
+            if (!downloadDir.exists()) {
+                downloadDir.mkdirs();
+            }
+        } catch (IOException | InterruptedException e) {
+            run.setResult(Result.UNSTABLE);
+        }
+
+        return downloadDir;
+    }
+
+    public Run<?, ?> getRun() {
+        return run;
+    }
+
+    public void setRun(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    public FilePath getWorkspace() {
+        return workspace;
+    }
+
+    public void setWorkspace(FilePath workspace) {
+        this.workspace = workspace;
+    }
+
+    public Launcher getLauncher() {
+        return launcher;
+    }
+
+    public void setLauncher(Launcher launcher) {
+        this.launcher = launcher;
+    }
+    public TaskListener getListener() {
+        return listener;
+    }
+
+    public void setListener(TaskListener listener) {
+        this.listener = listener;
+    }
+
+    public String getIncludeFilesPattern() {
+        return includeFilesPattern;
+    }
+
+    public void setIncludeFilesPattern(String includeFilesPattern) {
+        this.includeFilesPattern = includeFilesPattern;
+    }
+
+    public String getExcludeFilesPattern() {
+        return excludeFilesPattern;
+    }
+
+    public void setExcludeFilesPattern(String excludeFilesPattern) {
+        this.excludeFilesPattern = excludeFilesPattern;
+    }
+
+    public StorageAccountInfo getStorageAccountInfo() {
+        return storageAccountInfo;
+    }
+
+    public void setStorageAccountInfo(StorageAccountInfo storageAccountInfo) {
+        this.storageAccountInfo = storageAccountInfo;
+    }
+
+    public String getDownloadDirLoc() {
+        return downloadDirLoc;
+    }
+
+    public void setDownloadDirLoc(String downloadDirLoc) {
+        this.downloadDirLoc = downloadDirLoc;
+    }
+
+    public boolean isFlattenDirectories() {
+        return flattenDirectories;
+    }
+
+    public void setFlattenDirectories(boolean flattenDirectories) {
+        this.flattenDirectories = flattenDirectories;
+    }
+
+    public String getContainerName() {
+        return containerName;
+    }
+
+    public void setContainerName(String containerName) {
+        this.containerName = containerName;
+    }
+
+    public boolean isDeleteFromAzureAfterDownload() {
+        return deleteFromAzureAfterDownload;
+    }
+
+    public void setDeleteFromAzureAfterDownload(boolean deleteFromAzureAfterDownload) {
+        this.deleteFromAzureAfterDownload = deleteFromAzureAfterDownload;
+    }
+}

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilderContext.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilderContext.java
@@ -1,23 +1,17 @@
 /*
- * Copyright (c) Microsoft Corporation
- *   <p/>
- *  All rights reserved.
- *   <p/>
- *  MIT License
- *   <p/>
- *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
- *  documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- *  the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
- *  to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *  <p/>
- *  The above copyright notice and this permission notice shall be included in all copies or substantial portions of
- *  the Software.
- *   <p/>
- *  THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
- *  THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *  SOFTWARE.
+ Copyright 2016 Microsoft, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
 package com.microsoftopentechnologies.windowsazurestorage;
@@ -35,7 +29,7 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 
 public class AzureStorageBuilderContext {
-    private Run<?, ?> run;
+    Run<?, ?> run;
     Launcher launcher;
     TaskListener listener;
 

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
@@ -18,17 +18,7 @@ import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.RetryNoRetry;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.BlobContainerPermissions;
-import com.microsoft.azure.storage.blob.BlobContainerPublicAccessType;
-import com.microsoft.azure.storage.blob.BlobRequestOptions;
-import com.microsoft.azure.storage.blob.CloudBlob;
-import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.CloudBlobDirectory;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import com.microsoft.azure.storage.blob.ListBlobItem;
-import com.microsoft.azure.storage.blob.SharedAccessBlobPermissions;
-import com.microsoft.azure.storage.blob.SharedAccessBlobPolicy;
+import com.microsoft.azure.storage.blob.*;
 import com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher.UploadType;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
 import com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException;
@@ -39,6 +29,11 @@ import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.DirScanner.Glob;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.time.DurationFormatUtils;
+import org.springframework.util.AntPathMatcher;
+
+import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -48,26 +43,13 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.GregorianCalendar;
-import java.util.List;
-import java.util.StringTokenizer;
-import java.util.TimeZone;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.time.DurationFormatUtils;
-import org.springframework.util.AntPathMatcher;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.*;
 
 public class WAStorageClient {
 
     /*
-	 * A random name for container name to test validity of storage account
-	 * details
+     * A random name for container name to test validity of storage account
+     * details
      */
     private static final String TEST_CNT_NAME = "testcheckfromjenkins";
     private static final String BLOB = "blob";
@@ -85,85 +67,83 @@ public class WAStorageClient {
      * @throws WAStorageException
      */
     public static boolean validateStorageAccount(
-	    final StorageAccountInfo storageAccount) throws WAStorageException {
-	try {
-	    // Get container reference
-	    CloudBlobContainer container = getBlobContainerReference(
-		    storageAccount, TEST_CNT_NAME, false, false, null);
-	    container.exists();
+            final StorageAccountInfo storageAccount) throws WAStorageException {
+        try {
+            // Get container reference
+            CloudBlobContainer container = getBlobContainerReference(
+                    storageAccount, TEST_CNT_NAME, false, false, null);
+            container.exists();
 
-	} catch (Exception e) {
-	    throw new WAStorageException(Messages.Client_SA_val_fail());
-	}
-	return true;
+        } catch (Exception e) {
+            throw new WAStorageException(Messages.Client_SA_val_fail());
+        }
+        return true;
     }
 
     /**
      * Returns reference of Windows Azure cloud blob container.
      *
-     * @param accName storage account name
-     * @param key storage account primary access key
-     * @param blobURL blob service endpoint url
-     * @param containerName name of the container
-     * @param createCnt Indicates if container needs to be created
-     * @param allowRetry sets retry policy
-     * @param cntPubAccess Permissions for container
+     * @param storageAccount storage account info
+     * @param containerName  name of the container
+     * @param createCnt      Indicates if container needs to be created
+     * @param allowRetry     sets retry policy
+     * @param cntPubAccess   Permissions for container
      * @return reference of CloudBlobContainer
      * @throws URISyntaxException
      * @throws StorageException
      */
     private static CloudBlobContainer getBlobContainerReference(StorageAccountInfo storageAccount, String containerName,
-	    boolean createCnt, boolean allowRetry, Boolean cntPubAccess)
-	    throws URISyntaxException, StorageException, MalformedURLException, IOException {
+                                                                boolean createCnt, boolean allowRetry, Boolean cntPubAccess)
+            throws URISyntaxException, StorageException, MalformedURLException, IOException {
 
-	CloudStorageAccount cloudStorageAccount;
-	CloudBlobClient serviceClient;
-	CloudBlobContainer container;
-	StorageCredentialsAccountAndKey credentials;
-	String accName = storageAccount.getStorageAccName();
-	String blobURL = storageAccount.getBlobEndPointURL();
+        CloudStorageAccount cloudStorageAccount;
+        CloudBlobClient serviceClient;
+        CloudBlobContainer container;
+        StorageCredentialsAccountAndKey credentials;
+        String accName = storageAccount.getStorageAccName();
+        String blobURL = storageAccount.getBlobEndPointURL();
 
-	credentials = new StorageCredentialsAccountAndKey(accName, storageAccount.getStorageAccountKey());
+        credentials = new StorageCredentialsAccountAndKey(accName, storageAccount.getStorageAccountKey());
 
-	if (Utils.isNullOrEmpty(blobURL) || blobURL.equals(Constants.DEF_BLOB_URL)) {
-	    cloudStorageAccount = new CloudStorageAccount(credentials);
-	} else {
-		String endpointSuffix = getEndpointSuffix(blobURL);
-		if(Utils.isNullOrEmpty(endpointSuffix))
-			throw new URISyntaxException(blobURL,"The blob endpoint is not correct!");
-		cloudStorageAccount = new CloudStorageAccount(credentials, false, endpointSuffix);
-	}
+        if (Utils.isNullOrEmpty(blobURL) || blobURL.equals(Constants.DEF_BLOB_URL)) {
+            cloudStorageAccount = new CloudStorageAccount(credentials);
+        } else {
+            String endpointSuffix = getEndpointSuffix(blobURL);
+            if (Utils.isNullOrEmpty(endpointSuffix))
+                throw new URISyntaxException(blobURL, "The blob endpoint is not correct!");
+            cloudStorageAccount = new CloudStorageAccount(credentials, false, endpointSuffix);
+        }
 
-	serviceClient = cloudStorageAccount.createCloudBlobClient();
-	if (!allowRetry) {
-	    // Setting no retry policy
-	    RetryNoRetry rnr = new RetryNoRetry();
-	    // serviceClient.setRetryPolicyFactory(rnr);
-	    serviceClient.getDefaultRequestOptions().setRetryPolicyFactory(rnr);
-	}
+        serviceClient = cloudStorageAccount.createCloudBlobClient();
+        if (!allowRetry) {
+            // Setting no retry policy
+            RetryNoRetry rnr = new RetryNoRetry();
+            // serviceClient.setRetryPolicyFactory(rnr);
+            serviceClient.getDefaultRequestOptions().setRetryPolicyFactory(rnr);
+        }
 
-	container = serviceClient.getContainerReference(containerName);
+        container = serviceClient.getContainerReference(containerName);
 
-	boolean cntExists = container.exists();
+        boolean cntExists = container.exists();
 
-	if (createCnt && !cntExists) {
-	    container.createIfNotExists(null, Utils.updateUserAgent());
-	}
+        if (createCnt && !cntExists) {
+            container.createIfNotExists(null, Utils.updateUserAgent());
+        }
 
-	// Apply permissions only if container is created newly
-	if (!cntExists && cntPubAccess != null) {
-	    // Set access permissions on container.
-	    BlobContainerPermissions cntPerm;
-	    cntPerm = new BlobContainerPermissions();
-	    if (cntPubAccess) {
-		cntPerm.setPublicAccess(BlobContainerPublicAccessType.CONTAINER);
-	    } else {
-		cntPerm.setPublicAccess(BlobContainerPublicAccessType.OFF);
-	    }
-	    container.uploadPermissions(cntPerm);
-	}
+        // Apply permissions only if container is created newly
+        if (!cntExists && cntPubAccess != null) {
+            // Set access permissions on container.
+            BlobContainerPermissions cntPerm;
+            cntPerm = new BlobContainerPermissions();
+            if (cntPubAccess) {
+                cntPerm.setPublicAccess(BlobContainerPublicAccessType.CONTAINER);
+            } else {
+                cntPerm.setPublicAccess(BlobContainerPublicAccessType.OFF);
+            }
+            container.uploadPermissions(cntPerm);
+        }
 
-	return container;
+        return container;
     }
 
     /**
@@ -175,209 +155,207 @@ public class WAStorageClient {
      * @return
      */
     private static String getCustomURI(String storageAccountName, String type,
-	    String blobURL) {
-	if (QUEUE.equalsIgnoreCase(type)) {
-	    return blobURL.replace(storageAccountName + "." + BLOB,
-		    storageAccountName + "." + type);
-	} else if (TABLE.equalsIgnoreCase(type)) {
-	    return blobURL.replace(storageAccountName + "." + BLOB,
-		    storageAccountName + "." + type);
-	} else {
-	    return null;
-	}
+                                       String blobURL) {
+        if (QUEUE.equalsIgnoreCase(type)) {
+            return blobURL.replace(storageAccountName + "." + BLOB,
+                    storageAccountName + "." + type);
+        } else if (TABLE.equalsIgnoreCase(type)) {
+            return blobURL.replace(storageAccountName + "." + BLOB,
+                    storageAccountName + "." + type);
+        } else {
+            return null;
+        }
     }
 
     /**
      * Returns suffix for blob endpoint.
      *
-     * @param blob endpoint
+     * @param blobURL endpoint
      * @return the endpoint suffix
      */
-    private static String getEndpointSuffix(String blobURL)
-    {
-    	int endSuffixStartIndex = blobURL.toLowerCase().indexOf(Utils.BLOB_ENDPOINT_ENDSUFFIX_KEYWORD);
-    	if(endSuffixStartIndex < 0) {
-    		return null;
-    	} else {
-    		return blobURL.substring(endSuffixStartIndex);
-    	}
+    private static String getEndpointSuffix(String blobURL) {
+        int endSuffixStartIndex = blobURL.toLowerCase().indexOf(Utils.BLOB_ENDPOINT_ENDSUFFIX_KEYWORD);
+        if (endSuffixStartIndex < 0) {
+            return null;
+        } else {
+            return blobURL.substring(endSuffixStartIndex);
+        }
     }
 
     /**
-     *
      * @param listener
      * @param blob
      * @param src
      * @throws StorageException
      * @throws IOException
      * @throws InterruptedException
-	 * @returns Md5 hash of the uploaded file in hexadecimal encoding
+     * @returns Md5 hash of the uploaded file in hexadecimal encoding
      */
     protected static String upload(TaskListener listener, CloudBlockBlob blob, FilePath src)
-			throws StorageException, IOException, InterruptedException {
-		MessageDigest md = DigestUtils.getMd5Digest();
-		long startTime = System.currentTimeMillis();
-		try (InputStream inputStream = src.read(); DigestInputStream digestInputStream = new DigestInputStream(inputStream, md)){
-			blob.upload(digestInputStream, src.length(), null, getBlobRequestOptions(), Utils.updateUserAgent());
-		}
-		long endTime = System.currentTimeMillis();
-		listener.getLogger().println("Uploaded blob with uri " + blob.getUri() + " in " + getTime(endTime - startTime));
-		return DatatypeConverter.printHexBinary(md.digest());
+            throws StorageException, IOException, InterruptedException {
+        MessageDigest md = DigestUtils.getMd5Digest();
+        long startTime = System.currentTimeMillis();
+        try (InputStream inputStream = src.read(); DigestInputStream digestInputStream = new DigestInputStream(inputStream, md)) {
+            blob.upload(digestInputStream, src.length(), null, getBlobRequestOptions(), Utils.updateUserAgent());
+        }
+        long endTime = System.currentTimeMillis();
+        listener.getLogger().println("Uploaded blob with uri " + blob.getUri() + " in " + getTime(endTime - startTime));
+        return DatatypeConverter.printHexBinary(md.digest());
     }
 
     /**
      * Uploads files to Windows Azure Storage.
      *
-     * @param run environment of build
-     * @param listener logging
-     * @param launcher env vars for remote builds
-     * @param strAcc storage account information.
+     * @param run              environment of build
+     * @param listener         logging
+     * @param launcher         env vars for remote builds
+     * @param strAcc           storage account information.
      * @param expContainerName container name.
-     * @param cntPubAccess denotes if container is publicly accessible.
-     * @param expFP File Path in ant glob syntax relative to CI tool workspace.
-     * @param expVP Virtual Path of blob container.
-     * @param excludeFP File Path in ant glob syntax to exclude from upload
-     * @param uploadType upload file type
-     * @param individualBlobs blobs from build
-     * @param archiveBlobs blobs from build in archive files
+     * @param cntPubAccess     denotes if container is publicly accessible.
+     * @param expFP            File Path in ant glob syntax relative to CI tool workspace.
+     * @param expVP            Virtual Path of blob container.
+     * @param excludeFP        File Path in ant glob syntax to exclude from upload
+     * @param uploadType       upload file type
+     * @param individualBlobs  blobs from build
+     * @param archiveBlobs     blobs from build in archive files
      * @param cleanUpContainer if container is cleaned
      * @return filesUploaded number of files that are uploaded.
      * @throws WAStorageException throws exception
      */
     public static int upload(Run<?, ?> run, Launcher launcher, TaskListener listener,
-	    StorageAccountInfo strAcc, String expContainerName,
-	    AzureBlobProperties blobProperties,
-	    boolean cntPubAccess, boolean cleanUpContainer, String expFP,
-	    String expVP, String excludeFP, UploadType uploadType,
-	    List<AzureBlob> individualBlobs, List<AzureBlob> archiveBlobs, FilePath workspace) throws WAStorageException {
+                             StorageAccountInfo strAcc, String expContainerName,
+                             AzureBlobProperties blobProperties,
+                             boolean cntPubAccess, boolean cleanUpContainer, String expFP,
+                             String expVP, String excludeFP, UploadType uploadType,
+                             List<AzureBlob> individualBlobs, List<AzureBlob> archiveBlobs, FilePath workspace) throws WAStorageException {
 
-	int filesUploaded = 0; // Counter to track no. of files that are uploaded
+        int filesUploaded = 0; // Counter to track no. of files that are uploaded
 
-	try {
-	    FilePath workspacePath = new FilePath(launcher.getChannel(), workspace.getRemote());
+        try {
+            FilePath workspacePath = new FilePath(launcher.getChannel(), workspace.getRemote());
 
-	    listener.getLogger().println(
-		    Messages.WAStoragePublisher_uploading());
+            listener.getLogger().println(
+                    Messages.WAStoragePublisher_uploading());
 
-	    CloudBlobContainer container = WAStorageClient
-		    .getBlobContainerReference(strAcc, expContainerName,
-			    true, true, cntPubAccess);
+            CloudBlobContainer container = WAStorageClient
+                    .getBlobContainerReference(strAcc, expContainerName,
+                            true, true, cntPubAccess);
 
-	    // Delete previous contents if cleanup is needed
-	    if (cleanUpContainer) {
-		deleteContents(container);
-	    }
+            // Delete previous contents if cleanup is needed
+            if (cleanUpContainer) {
+                deleteContents(container);
+            }
 
-	    final String zipFolderName = "artifactsArchive";
-	    final String zipName = "archive.zip";
-	    // Make sure we exclude the tempPath from archiving.
-	    String excludesWithoutZip = "**/" + zipFolderName + "*/" + zipName;
-	    if (excludeFP != null) {
-		excludesWithoutZip = excludeFP + "," + excludesWithoutZip;
-	    }
-	    String archiveIncludes = "";
+            final String zipFolderName = "artifactsArchive";
+            final String zipName = "archive.zip";
+            // Make sure we exclude the tempPath from archiving.
+            String excludesWithoutZip = "**/" + zipFolderName + "*/" + zipName;
+            if (excludeFP != null) {
+                excludesWithoutZip = excludeFP + "," + excludesWithoutZip;
+            }
+            String archiveIncludes = "";
 
-	    StringTokenizer strTokens = new StringTokenizer(expFP, fpSeparator);
-	    while (strTokens.hasMoreElements()) {
-		String fileName = strTokens.nextToken();
+            StringTokenizer strTokens = new StringTokenizer(expFP, fpSeparator);
+            while (strTokens.hasMoreElements()) {
+                String fileName = strTokens.nextToken();
 
-		String embeddedVP = null;
+                String embeddedVP = null;
 
-		if (fileName != null && fileName.contains("::")) {
-		    int embVPSepIndex = fileName.indexOf("::");
+                if (fileName != null && fileName.contains("::")) {
+                    int embVPSepIndex = fileName.indexOf("::");
 
-		    // Separate fileName and Virtual directory name
-		    if (fileName.length() > embVPSepIndex + 1) {
-			embeddedVP = fileName.substring(embVPSepIndex + 2,
-				fileName.length());
+                    // Separate fileName and Virtual directory name
+                    if (fileName.length() > embVPSepIndex + 1) {
+                        embeddedVP = fileName.substring(embVPSepIndex + 2,
+                                fileName.length());
 
-			if (Utils.isNullOrEmpty(embeddedVP)) {
-			    embeddedVP = null;
-			} else if (!embeddedVP.endsWith(Constants.FWD_SLASH)) {
-			    embeddedVP = embeddedVP + Constants.FWD_SLASH;
-			}
-		    }
-		    fileName = fileName.substring(0, embVPSepIndex);
-		}
+                        if (Utils.isNullOrEmpty(embeddedVP)) {
+                            embeddedVP = null;
+                        } else if (!embeddedVP.endsWith(Constants.FWD_SLASH)) {
+                            embeddedVP = embeddedVP + Constants.FWD_SLASH;
+                        }
+                    }
+                    fileName = fileName.substring(0, embVPSepIndex);
+                }
 
-		archiveIncludes += "," + fileName;
+                archiveIncludes += "," + fileName;
 
-		// List all the paths without the zip archives.
-		FilePath[] paths = workspacePath.list(fileName, excludesWithoutZip);
-		filesUploaded += paths.length;
+                // List all the paths without the zip archives.
+                FilePath[] paths = workspacePath.list(fileName, excludesWithoutZip);
+                filesUploaded += paths.length;
 
-		URI workspaceURI = workspacePath.toURI();
+                URI workspaceURI = workspacePath.toURI();
 
-		if (uploadType == UploadType.INVALID) {
-		    // no files are uploaded
-		    return 0;
-		}
+                if (uploadType == UploadType.INVALID) {
+                    // no files are uploaded
+                    return 0;
+                }
 
-		if (paths.length != 0 && uploadType != UploadType.ZIP) {
-		    for (FilePath src : paths) {
-			// Remove the workspace bit of this path
-			URI srcURI = workspaceURI.relativize(src.toURI());
+                if (paths.length != 0 && uploadType != UploadType.ZIP) {
+                    for (FilePath src : paths) {
+                        // Remove the workspace bit of this path
+                        URI srcURI = workspaceURI.relativize(src.toURI());
 
-			CloudBlockBlob blob;
-			String srcPrefix = srcURI.getPath();
-			if (Utils.isNullOrEmpty(expVP)
-				&& Utils.isNullOrEmpty(embeddedVP)) {
-			    blob = container.getBlockBlobReference(srcPrefix);
-			} else {
-			    String prefix = expVP;
+                        CloudBlockBlob blob;
+                        String srcPrefix = srcURI.getPath();
+                        if (Utils.isNullOrEmpty(expVP)
+                                && Utils.isNullOrEmpty(embeddedVP)) {
+                            blob = container.getBlockBlobReference(srcPrefix);
+                        } else {
+                            String prefix = expVP;
 
-			    if (!Utils.isNullOrEmpty(embeddedVP)) {
-				if (Utils.isNullOrEmpty(expVP)) {
-				    prefix = embeddedVP;
-				} else {
-				    prefix = expVP + embeddedVP;
-				}
-			    }
-			    blob = container.getBlockBlobReference(prefix + srcPrefix);
-			}
+                            if (!Utils.isNullOrEmpty(embeddedVP)) {
+                                if (Utils.isNullOrEmpty(expVP)) {
+                                    prefix = embeddedVP;
+                                } else {
+                                    prefix = expVP + embeddedVP;
+                                }
+                            }
+                            blob = container.getBlockBlobReference(prefix + srcPrefix);
+                        }
 
-			// Set blob properties
-			if (blobProperties != null) {
-				blobProperties.configure(blob);
-			}
+                        // Set blob properties
+                        if (blobProperties != null) {
+                            blobProperties.configure(blob);
+                        }
 
-			String uploadedFileHash = upload(listener, blob, src);
-			individualBlobs.add(new AzureBlob(blob.getName(), blob.getUri().toString().replace("http://", "https://"), uploadedFileHash, src.length()));
-		    }
-		}
-	    }
+                        String uploadedFileHash = upload(listener, blob, src);
+                        individualBlobs.add(new AzureBlob(blob.getName(), blob.getUri().toString().replace("http://", "https://"), uploadedFileHash, src.length()));
+                    }
+                }
+            }
 
-	    if (filesUploaded != 0 && (uploadType != UploadType.INDIVIDUAL)) {
-		// Create a temp dir for the upload
-		FilePath tempPath = workspacePath.createTempDir(zipFolderName, null);
+            if (filesUploaded != 0 && (uploadType != UploadType.INDIVIDUAL)) {
+                // Create a temp dir for the upload
+                FilePath tempPath = workspacePath.createTempDir(zipFolderName, null);
 
-		Glob globScanner = new Glob(archiveIncludes, excludesWithoutZip);
+                Glob globScanner = new Glob(archiveIncludes, excludesWithoutZip);
 
-		FilePath zipPath = tempPath.child(zipName);
-		workspacePath.zip(zipPath.write(), globScanner);
+                FilePath zipPath = tempPath.child(zipName);
+                workspacePath.zip(zipPath.write(), globScanner);
 
-		// When uploading the zip, do not add in the tempDir to the block
-		// blob reference.
-		String blobURI = zipPath.getName();
+                // When uploading the zip, do not add in the tempDir to the block
+                // blob reference.
+                String blobURI = zipPath.getName();
 
-		if (!Utils.isNullOrEmpty(expVP)) {
-		    blobURI = expVP + blobURI;
-		}
+                if (!Utils.isNullOrEmpty(expVP)) {
+                    blobURI = expVP + blobURI;
+                }
 
-		CloudBlockBlob blob = container.getBlockBlobReference(blobURI);
+                CloudBlockBlob blob = container.getBlockBlobReference(blobURI);
 
-		String uploadedFileHash = upload(listener, blob, zipPath);
-		// Make sure to note the new blob as an archive blob,
-		// so that it can be specially marked on the azure storage page.
-		archiveBlobs.add(new AzureBlob(blob.getName(), blob.getUri().toString().replace("http://", "https://"), uploadedFileHash, zipPath.length()));
+                String uploadedFileHash = upload(listener, blob, zipPath);
+                // Make sure to note the new blob as an archive blob,
+                // so that it can be specially marked on the azure storage page.
+                archiveBlobs.add(new AzureBlob(blob.getName(), blob.getUri().toString().replace("http://", "https://"), uploadedFileHash, zipPath.length()));
 
-		tempPath.deleteRecursive();
-	    }
+                tempPath.deleteRecursive();
+            }
 
-	} catch (StorageException | IOException | InterruptedException | URISyntaxException e) {
-	    throw new WAStorageException(e.getMessage(), e.getCause());
-	}
-		return filesUploaded;
+        } catch (StorageException | IOException | InterruptedException | URISyntaxException e) {
+            throw new WAStorageException(e.getMessage(), e.getCause());
+        }
+        return filesUploaded;
     }
 
     /**
@@ -388,16 +366,16 @@ public class WAStorageClient {
      * @throws URISyntaxException
      */
     private static void deleteContents(CloudBlobContainer container)
-	    throws StorageException, URISyntaxException, MalformedURLException, IOException {
+            throws StorageException, URISyntaxException, MalformedURLException, IOException {
 
-	for (ListBlobItem blobItem : container.listBlobs()) {
-	    if (blobItem instanceof CloudBlob) {
+        for (ListBlobItem blobItem : container.listBlobs()) {
+            if (blobItem instanceof CloudBlob) {
                 ((CloudBlob) blobItem).uploadProperties(null, null, Utils.updateUserAgent());
                 ((CloudBlob) blobItem).delete();
-	    } else if (blobItem instanceof CloudBlobDirectory) {
-		deleteContents((CloudBlobDirectory) blobItem);
-	    }
-	}
+            } else if (blobItem instanceof CloudBlobDirectory) {
+                deleteContents((CloudBlobDirectory) blobItem);
+            }
+        }
     }
 
     /**
@@ -408,137 +386,136 @@ public class WAStorageClient {
      * @throws URISyntaxException
      */
     private static void deleteContents(CloudBlobDirectory cloudBlobDirectory)
-	    throws StorageException, URISyntaxException, MalformedURLException, IOException {
+            throws StorageException, URISyntaxException, IOException {
 
-	for (ListBlobItem blobItem : cloudBlobDirectory.listBlobs()) {
-	    if (blobItem instanceof CloudBlob) {
+        for (ListBlobItem blobItem : cloudBlobDirectory.listBlobs()) {
+            if (blobItem instanceof CloudBlob) {
                 ((CloudBlob) blobItem).uploadProperties(null, null, Utils.updateUserAgent());
                 ((CloudBlob) blobItem).delete();
-	    } else if (blobItem instanceof CloudBlobDirectory) {
-		deleteContents((CloudBlobDirectory) blobItem);
-	    }
-	}
+            } else if (blobItem instanceof CloudBlobDirectory) {
+                deleteContents((CloudBlobDirectory) blobItem);
+            }
+        }
+    }
+
+    public static int downloadFromContainer(AzureStorageBuilderContext context)
+            throws WAStorageException {
+        try {
+            context.getListener().getLogger().println(
+                    Messages.AzureStorageBuilder_downloading());
+            final CloudBlobContainer container = getBlobContainerReference(context.getStorageAccountInfo(), context.getContainerName(),
+                    false, true, null);
+            return downloadBlobs(container.listBlobs(), context);
+        } catch (WAStorageException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new WAStorageException(e.getMessage(), e.getCause());
+        }
     }
 
     /**
      * Downloads from Azure blob
      *
-     * @param run environment of build
-     * @param launcher env vars for remote builds
-     * @param listener logging
-     * @param strAcc storage account
-     * @param includePattern pattern to download
-     * @param excludePattern pattern to not download
-     * @param downloadDirLoc dir to download to
-     * @param flattenDirectories if directories are flattened
-     * @param workspace workspace of build
-     * @param containerName container with blobs
+     * @param azureBlobs blobs from build
+     * @param context    the download context
      * @return filesDownloaded number of files that are downloaded
      * @throws WAStorageException throws exception
      */
-    public static int download(Run<?, ?> run, Launcher launcher,
-            TaskListener listener, StorageAccountInfo strAcc, String includePattern, String excludePattern,
-            String downloadDirLoc, boolean flattenDirectories, FilePath workspace, String containerName)
+    public static int downloadArtifacts(final List<AzureBlob> azureBlobs, final AzureStorageBuilderContext context)
             throws WAStorageException {
 
         int filesDownloaded = 0;
-        try {
-            FilePath workspacePath = new FilePath(launcher.getChannel(), workspace.getRemote());
-            FilePath downloadDir = getDownloadDir(workspacePath, downloadDirLoc);
-            listener.getLogger().println(
-                    Messages.AzureStorageBuilder_downloading());
-            CloudBlobContainer container = WAStorageClient
-                    .getBlobContainerReference(strAcc, containerName,
-                            false, true, null);
-            filesDownloaded = downloadBlobs(container, includePattern, excludePattern,
-                    downloadDir, flattenDirectories, listener);
-        } catch (Exception e) {
-            throw new WAStorageException(e.getMessage(), e.getCause());
+
+        for (final AzureBlob blob : azureBlobs) {
+            try {
+                context.getListener().getLogger().println(Messages.AzureStorageBuilder_downloading());
+
+                final URL blobURL = new URL(blob.getBlobURL());
+                final String filePath = blobURL.getFile();
+
+                final CloudBlobContainer container = getBlobContainerReference(context.getStorageAccountInfo(),
+                        filePath.split("/")[1], false, true, null);
+
+                if (shouldDownload(context.getIncludeFilesPattern(), context.getExcludeFilesPattern(), blob.getBlobName(), true)) {
+                    final CloudBlockBlob cbb = container.getBlockBlobReference(blob.getBlobName());
+                    downloadBlob(cbb, context);
+                    filesDownloaded++;
+                }
+            } catch (StorageException | URISyntaxException | IOException e) {
+                throw new WAStorageException(e.getMessage(), e.getCause());
+            }
         }
         return filesDownloaded;
     }
 
-    /**
-     * Downloads from Azure blob
-     *
-     * @param run environment of build
-     * @param launcher env vars for remote builds
-     * @param listener logging
-     * @param strAcc storage account
-     * @param blobs blobs from build
-     * @param includePattern pattern to download
-     * @param excludePattern pattern to not download
-     * @param downloadDirLoc dir to download to
-     * @param flattenDirectories if directories are flattened
-     * @param workspace workspace of build
-     * @return filesDownloaded number of files that are downloaded
-     * @throws WAStorageException throws exception
-     */
-    public static int download(Run<?, ?> run, Launcher launcher,
-	    TaskListener listener, StorageAccountInfo strAcc,
-	    List<AzureBlob> blobs, String includePattern, String excludePattern,
-	    String downloadDirLoc, boolean flattenDirectories, FilePath workspace)
-	    throws WAStorageException {
+    private static int downloadBlobs(final Iterable<ListBlobItem> blobItems, final AzureStorageBuilderContext context)
+            throws URISyntaxException, StorageException, WAStorageException {
+        int filesDownloaded = 0;
+        for (final ListBlobItem blobItem : blobItems) {
+            // If the item is a blob, not a virtual directory
+            if (blobItem instanceof CloudBlob) {
+                // Download the item and save it to a file with the same
+                final CloudBlob blob = (CloudBlob) blobItem;
 
-	int filesDownloaded = 0;
+                // Check whether we should download it.
+                if (shouldDownload(context.getIncludeFilesPattern(), context.getExcludeFilesPattern(), blob.getName(), true)) {
+                    downloadBlob(blob, context);
+                    filesDownloaded++;
+                }
 
-	for (AzureBlob blob : blobs) {
-	    try {
-		FilePath workspacePath = new FilePath(launcher.getChannel(), workspace.getRemote());
-
-		FilePath downloadDir = getDownloadDir(workspacePath, downloadDirLoc);
-
-		listener.getLogger().println(
-			Messages.AzureStorageBuilder_downloading());
-
-		URL blobURL = new URL(blob.getBlobURL());
-		String filePath = blobURL.getFile();
-
-		CloudBlobContainer container = WAStorageClient
-			.getBlobContainerReference(strAcc, filePath.split("/")[1],
-				false, true, null);
-
-		if (shouldDownload(includePattern, excludePattern, blob.getBlobName())) {
-		    filesDownloaded += downloadBlobs(container, blob, downloadDir, flattenDirectories, listener);
-		}
-
-	    } catch (Exception e) {
-		throw new WAStorageException(e.getMessage(), e.getCause());
-	    }
-	}
-	return filesDownloaded;
+            } else if (blobItem instanceof CloudBlobDirectory) {
+                final CloudBlobDirectory blobDirectory = (CloudBlobDirectory) blobItem;
+                if (shouldDownload(context.getIncludeFilesPattern(), context.getExcludeFilesPattern(), blobDirectory.getPrefix(), false)) {
+                    filesDownloaded += downloadBlobs(blobDirectory.listBlobs(), context);
+                }
+            }
+        }
+        return filesDownloaded;
     }
 
-    private static boolean shouldDownload(String includePattern, String excludePattern, String blobName) {
-	String[] includePatterns = includePattern.split(fpSeparator);
-	String[] excludePatterns = null;
+    private static void downloadBlob(final CloudBlob blob, final AzureStorageBuilderContext context)
+            throws WAStorageException {
+        try {
+            final FilePath downloadDir = context.getDownloadDir();
+            FilePath downloadFile = new FilePath(downloadDir, blob.getName());
 
-	if (excludePattern != null) {
-	    excludePatterns = excludePattern.split(fpSeparator);
-	}
+            // That filepath will contain all the directories and explicit virtual
+            // paths, so if the user wanted it flattened, grab just the file name and
+            // recreate the file path
+            if (context.isFlattenDirectories()) {
+                downloadFile = new FilePath(downloadDir, downloadFile.getName());
+            }
 
-	return blobPathMatches(blobName, includePatterns, excludePatterns);
+            final long startTime = System.currentTimeMillis();
+            try (OutputStream fos = downloadFile.write()) {
+                blob.download(fos, null, getBlobRequestOptions(), Utils.updateUserAgent());
+            }
+            final long endTime = System.currentTimeMillis();
+
+            context.getListener().getLogger().println(
+                    "blob " + blob.getName() + " is downloaded to "
+                            + downloadDir + " in "
+                            + getTime(endTime - startTime));
+
+            if (context.isDeleteFromAzureAfterDownload()) {
+                blob.deleteIfExists();
+                context.getListener().getLogger().println(
+                        "blob " + blob.getName() + " is deleted from Azure.");
+            }
+        } catch (Exception e) {
+            throw new WAStorageException(e.getMessage(), e.getCause());
+        }
     }
 
-    private static FilePath getDownloadDir(FilePath workspacePath, String downloadDirLoc) {
-	FilePath downloadDir;
-	if (Utils.isNullOrEmpty(downloadDirLoc)) {
-	    downloadDir = workspacePath;
-	} else {
-	    downloadDir = new FilePath(workspacePath, downloadDirLoc);
-	}
-	try {
-	    if (!downloadDir.exists()) {
-		downloadDir.mkdirs();
-	    }
-	} catch (Exception e) {
-	}
+    private static boolean shouldDownload(String includePattern, String excludePattern, String blobName, boolean isFullPath) {
+        String[] includePatterns = includePattern.split(fpSeparator);
+        String[] excludePatterns = null;
 
-	return downloadDir;
-    }
+        if (excludePattern != null) {
+            excludePatterns = excludePattern.split(fpSeparator);
+        }
 
-    private static boolean blobPathMatches(String path, String[] includePatterns, String[] excludePatterns) {
-	return isExactMatch(path, includePatterns) && (excludePatterns == null || !isExactMatch(path, excludePatterns));
+        return blobPathMatches(blobName, includePatterns, excludePatterns, isFullPath);
     }
 
     private static boolean blobPathMatches(String path, String[] includePatterns, String[] excludePatterns, boolean isFullPath) {
@@ -579,170 +556,13 @@ public class WAStorageClient {
      * @return
      */
     private static boolean isExactMatch(String path, String[] patterns) {
-	AntPathMatcher matcher = new AntPathMatcher();
-	for (String pattern : patterns) {
-	    if (matcher.match(pattern, path)) {
-		return true;
-	    }
-	}
-	return false;
-    }
-
-    /**
-     * Downloads blobs
-     *
-     * @param container
-     * @param blob
-     * @param downloadDir
-     * @param flattenDirectories
-     * @param listener
-     * @return
-     */
-    private static int downloadBlobs(CloudBlobContainer container, AzureBlob blob, FilePath downloadDir, boolean flattenDirectories, TaskListener listener) {
-	int filesDownloaded = 0;
-	try {
-	    CloudBlockBlob cbb = container.getBlockBlobReference(blob.getBlobName());
-	    downloadBlob(cbb, downloadDir, flattenDirectories, listener);
-	    filesDownloaded++;
-	} catch (URISyntaxException ex) {
-	    Logger.getLogger(WAStorageClient.class.getName()).log(Level.SEVERE, null, ex);
-	} catch (StorageException ex) {
-	    Logger.getLogger(WAStorageClient.class.getName()).log(Level.SEVERE, null, ex);
-	} catch (WAStorageException ex) {
-	    listener.getLogger().println("blob " + blob.getBlobName() + " was not found");
-	}
-	return filesDownloaded;
-    }
-
-    /**
-     *
-     * @param container
-     * @param includePattern
-     * @param excludePattern
-     * @param downloadDir
-     * @param flattenDirectories
-     * @param listener
-     * @return
-     * @throws WAStorageException
-     * @throws URISyntaxException
-     * @throws IOException
-     * @throws StorageException
-     */
-    private static int downloadBlobs(CloudBlobContainer container,
-            String includePattern, String excludePattern,
-            FilePath downloadDir, boolean flattenDirectories, TaskListener listener) throws WAStorageException, URISyntaxException, IOException, StorageException {
-        int filesDownloaded = 0;
-        String[] includePatterns = includePattern.split(fpSeparator);
-        String[] excludePatterns = null;
-
-        if (excludePattern != null) {
-            excludePatterns = excludePattern.split(fpSeparator);
-        }
-
-        for (ListBlobItem blobItem : container.listBlobs()) {
-            // If the item is a blob, not a virtual directory
-            if (blobItem instanceof CloudBlob) {
-                // Download the item and save it to a file with the same
-                // name
-                CloudBlob blob = (CloudBlob) blobItem;
-
-                // Check whether we should download it.
-                if (blobPathMatches(blob.getName(), includePatterns, excludePatterns, true)) {
-                    downloadBlob((CloudBlockBlob) blob, downloadDir, flattenDirectories, listener);
-                    filesDownloaded++;
-                }
-
-            } else if (blobItem instanceof CloudBlobDirectory) {
-                CloudBlobDirectory blobDirectory = (CloudBlobDirectory) blobItem;
-                filesDownloaded += downloadBlob(blobDirectory, includePatterns,
-                        excludePatterns, downloadDir, flattenDirectories, listener);
+        AntPathMatcher matcher = new AntPathMatcher();
+        for (String pattern : patterns) {
+            if (matcher.match(pattern, path)) {
+                return true;
             }
         }
-        return filesDownloaded;
-    }
-
-    /**
-     * Blob download from storage
-     *
-     * @param blob
-     * @param downloadDir
-     * @param listener
-     * @throws URISyntaxException
-     * @throws StorageException
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    private static void downloadBlob(CloudBlob blob, FilePath downloadDir, boolean flattenDirectories,
-	    TaskListener listener) throws WAStorageException {
-		try {
-			FilePath downloadFile = new FilePath(downloadDir, blob.getName());
-
-			// That filepath will contain all the directories and explicit virtual
-			// paths, so if the user wanted it flattened, grab just the file name and
-			// recreate the file path
-			if (flattenDirectories) {
-				downloadFile = new FilePath(downloadDir, downloadFile.getName());
-			}
-
-			long startTime = System.currentTimeMillis();
-			try (OutputStream fos = downloadFile.write()) {
-				blob.download(fos, null, getBlobRequestOptions(), Utils.updateUserAgent());
-			}
-			long endTime = System.currentTimeMillis();
-
-			listener.getLogger().println(
-					"blob " + blob.getName() + " is downloaded to "
-							+ downloadDir + " in "
-							+ getTime(endTime - startTime));
-		} catch (Exception e) {
-			throw new WAStorageException(e.getMessage(), e.getCause());
-		}
-    }
-
-    /**
-     * Blob download from storage
-     *
-     * @param blobDirectory
-     * @param includePatterns
-     * @param excludePaterns
-     * @param downloadDir
-     * @param flattenDirectories
-     * @param listener
-     * @throws URISyntaxException
-     * @throws StorageException
-     * @throws IOException
-     * @throws WAStorageException
-     */
-    private static int downloadBlob(CloudBlobDirectory blobDirectory,
-            String[] includePatterns, String[] excludePatterns,
-            FilePath downloadDir, boolean flattenDirectories, TaskListener listener)
-            throws StorageException, URISyntaxException, IOException,
-            WAStorageException {
-
-        if (!blobPathMatches(blobDirectory.getPrefix(), includePatterns, excludePatterns, false)) {
-            return 0;
-        }
-        int filesDownloaded = 0;
-
-        for (ListBlobItem blobItem : blobDirectory.listBlobs()) {
-            // If the item is a blob, not a virtual directory
-            if (blobItem instanceof CloudBlob) {
-                // Download the item and save it to a file with the same
-                // name
-                CloudBlob blob = (CloudBlob) blobItem;
-
-                if (blobPathMatches(blob.getName(), includePatterns, excludePatterns, true)) {
-                    downloadBlob(blob, downloadDir, flattenDirectories, listener);
-                    filesDownloaded++;
-                }
-            } else if (blobItem instanceof CloudBlobDirectory) {
-                CloudBlobDirectory blobDir = (CloudBlobDirectory) blobItem;
-                filesDownloaded += downloadBlob(blobDir, includePatterns, excludePatterns,
-                        downloadDir, flattenDirectories, listener);
-            }
-        }
-
-        return filesDownloaded;
+        return false;
     }
 
     /**
@@ -750,45 +570,45 @@ public class WAStorageClient {
      *
      * @param storageAccount
      * @param blobName
-     * @param containerName container name
+     * @param containerName  container name
      * @return SAS URL
      * @throws Exception
      */
     public static String generateSASURL(StorageAccountInfo storageAccount, String containerName, String blobName) throws Exception {
-	String storageAccountName = storageAccount.getStorageAccName();
-	StorageCredentialsAccountAndKey credentials = new StorageCredentialsAccountAndKey(storageAccountName, storageAccount.getStorageAccountKey());
-	URL blobURL = new URL(storageAccount.getBlobEndPointURL());
-	String saBlobURI = new StringBuilder().append(blobURL.getProtocol()).append("://").append(storageAccountName).append(".")
-		.append(blobURL.getHost()).append("/").toString();
-	CloudStorageAccount cloudStorageAccount = new CloudStorageAccount(credentials, new URI(saBlobURI),
-		new URI(getCustomURI(storageAccountName, QUEUE, saBlobURI)),
-		new URI(getCustomURI(storageAccountName, TABLE, saBlobURI)));
-	// Create the blob client.
-	CloudBlobClient blobClient = cloudStorageAccount.createCloudBlobClient();
-	CloudBlobContainer container = blobClient.getContainerReference(containerName);
+        String storageAccountName = storageAccount.getStorageAccName();
+        StorageCredentialsAccountAndKey credentials = new StorageCredentialsAccountAndKey(storageAccountName, storageAccount.getStorageAccountKey());
+        URL blobURL = new URL(storageAccount.getBlobEndPointURL());
+        String saBlobURI = new StringBuilder().append(blobURL.getProtocol()).append("://").append(storageAccountName).append(".")
+                .append(blobURL.getHost()).append("/").toString();
+        CloudStorageAccount cloudStorageAccount = new CloudStorageAccount(credentials, new URI(saBlobURI),
+                new URI(getCustomURI(storageAccountName, QUEUE, saBlobURI)),
+                new URI(getCustomURI(storageAccountName, TABLE, saBlobURI)));
+        // Create the blob client.
+        CloudBlobClient blobClient = cloudStorageAccount.createCloudBlobClient();
+        CloudBlobContainer container = blobClient.getContainerReference(containerName);
 
-	// At this point need to throw an error back since container itself did not exist.
-	if (!container.exists()) {
-	    throw new Exception("WAStorageClient: generateSASURL: Container " + containerName
-		    + " does not exist in storage account " + storageAccountName);
-	}
+        // At this point need to throw an error back since container itself did not exist.
+        if (!container.exists()) {
+            throw new Exception("WAStorageClient: generateSASURL: Container " + containerName
+                    + " does not exist in storage account " + storageAccountName);
+        }
 
-	CloudBlob blob = container.getBlockBlobReference(blobName);
-	String sas = blob.generateSharedAccessSignature(generatePolicy(), null);
+        CloudBlob blob = container.getBlockBlobReference(blobName);
+        String sas = blob.generateSharedAccessSignature(generatePolicy(), null);
 
-	return sas;
+        return sas;
     }
 
     public static SharedAccessBlobPolicy generatePolicy() {
-	SharedAccessBlobPolicy policy = new SharedAccessBlobPolicy();
-	GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
-	calendar.setTime(new Date());
+        SharedAccessBlobPolicy policy = new SharedAccessBlobPolicy();
+        GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        calendar.setTime(new Date());
 
-	calendar.add(Calendar.HOUR, 1);
-	policy.setSharedAccessExpiryTime(calendar.getTime());
-	policy.setPermissions(EnumSet.of(SharedAccessBlobPermissions.READ));
+        calendar.add(Calendar.HOUR, 1);
+        policy.setSharedAccessExpiryTime(calendar.getTime());
+        policy.setPermissions(EnumSet.of(SharedAccessBlobPermissions.READ));
 
-	return policy;
+        return policy;
     }
 
     /**
@@ -798,14 +618,14 @@ public class WAStorageClient {
      * @return
      */
     private static BlobRequestOptions getBlobRequestOptions() {
-	BlobRequestOptions options = new BlobRequestOptions();
-	options.setConcurrentRequestCount(Runtime.getRuntime().availableProcessors());
+        BlobRequestOptions options = new BlobRequestOptions();
+        options.setConcurrentRequestCount(Runtime.getRuntime().availableProcessors());
 
-	return options;
+        return options;
     }
 
     public static String getTime(long timeInMills) {
-	return DurationFormatUtils.formatDuration(timeInMills, "HH:mm:ss.S")
-		+ " (HH:mm:ss.S)";
+        return DurationFormatUtils.formatDuration(timeInMills, "HH:mm:ss.S")
+                + " (HH:mm:ss.S)";
     }
 }

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
@@ -46,11 +46,18 @@
                 </div>
             </f:entry>
 
+            <f:entry field="deleteFromAzureAfterDownload" help="/plugin/windows-azure-storage/help-deleteFromAzureAfterDownload.html">
+                <div align="left">
+                    <f:checkbox  title="${%includeArchiveZips_title}"/>
+                </div>
+            </f:entry>
+
             <f:entry field="includeArchiveZips" help="/plugin/windows-azure-storage/help-includeArchiveZips.html">
                 <div align="left">
                     <f:checkbox  title="${%includeArchiveZips_title}"/>
                 </div>
             </f:entry>
+
         </f:advanced>
     </f:section>
 

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.jelly
@@ -48,7 +48,7 @@
 
             <f:entry field="deleteFromAzureAfterDownload" help="/plugin/windows-azure-storage/help-deleteFromAzureAfterDownload.html">
                 <div align="left">
-                    <f:checkbox  title="${%includeArchiveZips_title}"/>
+                    <f:checkbox  title="${%deleteFromAzureAfterDownload_title}"/>
                 </div>
             </f:entry>
 

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder/config.properties
@@ -6,4 +6,5 @@ includePattern_title=Files to download (ant syntax)
 excludePattern_title=Files to exclude from download (ant syntax) (Optional)
 download_dir_location_title=Download path (Optional):
 flattenDirectories_title=Flatten directories
+deleteFromAzureAfterDownload_title=Delete from Azure after download
 includeArchiveZips_title=Include archive zips

--- a/src/main/webapp/help-deleteFromAzureAfterDownload.html
+++ b/src/main/webapp/help-deleteFromAzureAfterDownload.html
@@ -1,0 +1,3 @@
+<div>
+	If checked, the file copy on Azure will be removed after it's downloaded to local.
+</div>

--- a/src/test/java/IntegrationTests/WAStorageClientDownloadIT.java
+++ b/src/test/java/IntegrationTests/WAStorageClientDownloadIT.java
@@ -1,17 +1,21 @@
 package IntegrationTests;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.ResultSegment;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.microsoftopentechnologies.windowsazurestorage.AzureStorageBuilderContext;
 import com.microsoftopentechnologies.windowsazurestorage.WAStorageClient;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
@@ -19,12 +23,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.junit.Before;
+
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -74,11 +74,18 @@ public class WAStorageClientDownloadIT extends IntegrationTest{
             Run mockRun = mock(Run.class);
             Launcher mockLauncher = mock(Launcher.class);
             WAStorageClient mockStorageClient = spy(WAStorageClient.class);
-            
+
+            AzureStorageBuilderContext context = new AzureStorageBuilderContext(mockLauncher, mockRun, TaskListener.NULL);
+            context.setStorageAccountInfo(testEnv.sampleStorageAccount);
+            context.setIncludeFilesPattern("*.txt");
+            context.setExcludeFilesPattern("archive.zip");
+
             File downloaded = new File(new File(".").getAbsolutePath(), TestEnvironment.GenerateRandomString(5));
             downloaded.mkdir();
             FilePath workspace= new FilePath(downloaded.getAbsoluteFile());
-            int totalFiles = mockStorageClient.download(mockRun, mockLauncher, TaskListener.NULL, testEnv.sampleStorageAccount, "*.txt", ",archive.zip", "", false, workspace, testEnv.containerName);
+            context.setWorkspace(workspace);
+            context.setContainerName(testEnv.containerName);
+            int totalFiles = mockStorageClient.downloadFromContainer(context);
             
             
             assertEquals(testEnv.downloadFileList.size(),totalFiles);
@@ -114,10 +121,16 @@ public class WAStorageClientDownloadIT extends IntegrationTest{
             Launcher mockLauncher = mock(Launcher.class);
             WAStorageClient mockStorageClient = spy(WAStorageClient.class);
 
+            AzureStorageBuilderContext context = new AzureStorageBuilderContext(mockLauncher, mockRun, TaskListener.NULL);
+            context.setStorageAccountInfo(testEnv.sampleStorageAccount);
+            context.setIncludeFilesPattern("*.txt");
+
             File downloaded = new File(new File(".").getAbsolutePath(), TestEnvironment.GenerateRandomString(5));
             downloaded.mkdir();
             FilePath workspace = new FilePath(downloaded.getAbsoluteFile());
-            int totalFiles = mockStorageClient.download(mockRun, mockLauncher, TaskListener.NULL, testEnv.sampleStorageAccount, "*.txt", "", "", false, workspace, testEnv.containerName);
+            context.setWorkspace(workspace);
+            context.setContainerName(testEnv.containerName);
+            int totalFiles = mockStorageClient.downloadFromContainer(context);
 
             assertEquals(testEnv.downloadFileList.size(), totalFiles);
             File[] listofFiles = downloaded.listFiles();
@@ -151,10 +164,17 @@ public class WAStorageClientDownloadIT extends IntegrationTest{
             Launcher mockLauncher = mock(Launcher.class);
             WAStorageClient mockStorageClient = spy(WAStorageClient.class);
 
+            AzureStorageBuilderContext context = new AzureStorageBuilderContext(mockLauncher, mockRun, TaskListener.NULL);
+            context.setStorageAccountInfo(testEnv.sampleStorageAccount);
+            context.setIncludeFilesPattern("*.txt");
+
             File downloaded = new File(new File(".").getAbsolutePath(), TestEnvironment.GenerateRandomString(5));
             downloaded.mkdir();
             FilePath workspace = new FilePath(downloaded.getAbsoluteFile());
-            int totalFiles = mockStorageClient.download(mockRun, mockLauncher, TaskListener.NULL, testEnv.sampleStorageAccount, "*.txt", "", "", true, workspace, testEnv.containerName);
+            context.setWorkspace(workspace);
+            context.setContainerName(testEnv.containerName);
+            context.setFlattenDirectories(true);
+            int totalFiles = mockStorageClient.downloadFromContainer(context);
 
             assertEquals(testEnv.downloadFileList.size(), totalFiles);
             File[] listofFiles = downloaded.listFiles();


### PR DESCRIPTION
resolve https://github.com/jenkinsci/windows-azure-storage-plugin/issues/42 by:
- adding an option in advanced settings. If it's checked the original copy on azure will be deleted after downloaded to local
- add `AzureStorageBuilderContext` as a model class to avoid too many parameters in method signatures.
- remove duplicated code blocks.
- fix affected unit tests.

Testing performed:
- download files
- download files recursively
- download files with exclusion
- download files with `flatten` enabled
- download files with `delete from azure` enabled
