### PR TITLE
Provide an option to auto detect content type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <name>Windows Azure Storage plugin</name>
   <description>Uploads build artifacts or downloads build dependencies using Azure storage</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Windows+Azure+Storage+Plugin</url>
-  
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -23,14 +23,14 @@
         <findbugs.excludeFilterFile>exclude-findbugs.xml</findbugs.excludeFilterFile>
 	<maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
-    
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0 (the "License")</name>
             <comments>Licensed under the Apache License, Version 2.0 (the "License").</comments>
         </license>
     </licenses>
-  
+
   <developers>
     	<developer>
       		<id>clguiman</id>
@@ -88,6 +88,11 @@
             <version>1.10</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.14</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.3</version>
@@ -110,14 +115,14 @@
             <version>4.11</version>
         </dependency>
     </dependencies>
-   
+
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/windows-azure-storage-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/windows-azure-storage-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/windows-azure-storage-plugin</url>
         <tag>HEAD</tag>
     </scm>
-  
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -131,7 +136,7 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-  
+
   <build>
 	<plugins>
 		<plugin>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStorageClient.java
@@ -320,7 +320,7 @@ public class WAStorageClient {
 
                         // Set blob properties
                         if (blobProperties != null) {
-                            blobProperties.configure(blob, env);
+                            blobProperties.configure(blob, src, env);
                         }
 
                         // Set blob metadata

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/config.jelly
@@ -14,4 +14,11 @@
     <f:entry title="${%contentType_title}" field="contentType">
         <f:textbox />
     </f:entry>
+
+    <f:entry field="detectContentType">
+        <div align="left">
+            <f:checkbox title="${%detectContentType_title}" default="true" />
+        </div>
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/config.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/config.properties
@@ -2,3 +2,4 @@ cacheControl_title=Cache control
 contentEncoding_title=Content encoding
 contentLanguage_title=Content language
 contentType_title=Content type
+detectContentType_title=Auto detect content type

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/help-detectContentType.html
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/help-detectContentType.html
@@ -1,0 +1,5 @@
+<div>
+    <p>Auto detect content type based on file content and file name if content type is not set.</p>
+
+    <p>This detection is provided by <a href="https://tika.apache.org">Apache Tika</a> and may not always be accurate.</p>
+</div>

--- a/src/test/java/IntegrationTests/WAStorageClientUploadIT.java
+++ b/src/test/java/IntegrationTests/WAStorageClientUploadIT.java
@@ -159,7 +159,8 @@ public class WAStorageClientUploadIT extends IntegrationTest {
                 "no-cache",
                 "identity",
                 "en-US",
-                "text/plain"
+                "text/plain",
+                false
             );
             List<AzureBlobMetadataPair> metadata = Arrays.asList(
                 new AzureBlobMetadataPair("k1", "v1"),
@@ -204,7 +205,7 @@ public class WAStorageClientUploadIT extends IntegrationTest {
             Launcher mockLauncher = mock(Launcher.class);
             List<AzureBlob> individualBlobs = new ArrayList<>();
             List<AzureBlob> archiveBlobs = new ArrayList<>();
-            AzureBlobProperties blobProperties = new AzureBlobProperties(null, null, null, null);
+            AzureBlobProperties blobProperties = new AzureBlobProperties(null, null, null, null, false);
             List<AzureBlobMetadataPair> metadata = Arrays.asList(
                     new AzureBlobMetadataPair(null, "v1"),
                     new AzureBlobMetadataPair("", "v1"),
@@ -254,7 +255,8 @@ public class WAStorageClientUploadIT extends IntegrationTest {
                     null,
                     null,
                     null,
-                    "${MY_CONTENT_TYPE}"
+                    "${MY_CONTENT_TYPE}",
+                    false
             );
             List<AzureBlobMetadataPair> metadata = Arrays.asList(
                     new AzureBlobMetadataPair("${MY_META_KEY}", "${MY_META_VALUE}")

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobPropertiesTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobPropertiesTest.java
@@ -1,0 +1,83 @@
+package com.microsoftopentechnologies.windowsazurestorage;
+
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlob;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import hudson.EnvVars;
+import hudson.FilePath;
+import junit.framework.TestCase;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class AzureBlobPropertiesTest extends TestCase {
+
+    private File file;
+    private FilePath filePath;
+
+    @Before
+    public void setUp() throws IOException {
+        file = new File("index.html");
+        file.deleteOnExit();
+        FileUtils.writeStringToFile(file, "<p>Hello Azure!</p>");
+        filePath = new FilePath(file);
+    }
+
+    @Test
+    public void testEnvVarsResolve() throws URISyntaxException, StorageException, IOException, InterruptedException {
+        final EnvVars env = new EnvVars("foo", "bar");
+        final CloudBlob blob = new CloudBlockBlob(new URI("https://example.com/index.html"));
+        final AzureBlobProperties props = new AzureBlobProperties(
+                "${foo}",
+                "${foo}",
+                "${foo}",
+                "${foo}",
+                false
+        );
+
+        props.configure(blob, filePath, env);
+
+        assertEquals("bar", blob.getProperties().getCacheControl());
+        assertEquals("bar", blob.getProperties().getContentEncoding());
+        assertEquals("bar", blob.getProperties().getContentLanguage());
+        assertEquals("bar", blob.getProperties().getContentType());
+    }
+
+    @Test
+    public void testDetectContentType() throws URISyntaxException, StorageException, IOException, InterruptedException {
+        final EnvVars env = new EnvVars();
+        final CloudBlob blob = new CloudBlockBlob(new URI("https://example.com/index.html"));
+        final AzureBlobProperties props = new AzureBlobProperties(null, null, null, null, true);
+
+        props.configure(blob, filePath, env);
+
+        assertEquals("text/html", blob.getProperties().getContentType());
+    }
+
+    @Test
+    public void testDoNotDetectContentTypeIfSet() throws URISyntaxException, StorageException, IOException, InterruptedException {
+        final EnvVars env = new EnvVars();
+        final CloudBlob blob = new CloudBlockBlob(new URI("https://example.com/index.html"));
+        final AzureBlobProperties props = new AzureBlobProperties(null, null, null, "text/plain", true);
+
+        props.configure(blob, filePath, env);
+
+        assertEquals("text/plain", blob.getProperties().getContentType());
+    }
+
+    @Test
+    public void testDoNotDetectContentTypeIfNotEnabled() throws URISyntaxException, StorageException, IOException, InterruptedException {
+        final EnvVars env = new EnvVars();
+        final CloudBlob blob = new CloudBlockBlob(new URI("https://example.com/index.html"));
+        final AzureBlobProperties props = new AzureBlobProperties(null, null, null, null, false);
+
+        props.configure(blob, filePath, env);
+
+        assertNull(blob.getProperties().getContentType());
+    }
+}


### PR DESCRIPTION
This PR gives user an option to auto detect content type of the blob based on the file name and content.

The detection ability is provided by [Apache Tika](https://tika.apache.org/).