### PR TITLE
remove integration test from verify phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,14 +178,6 @@
                     <threadCountMethods>10</threadCountMethods>
                     <parallel>methods</parallel>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
remove integration test from verify phase because the integration test broken our CI process for required environment variables cannot be read correctly.  Since the integration tests are already included in CI, just remove it from verify phase to avoid duplication.