### PR TITLE
fix issue #84: cannot download artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <findbugs.failOnError>true</findbugs.failOnError>
         <findbugs.excludeFilterFile>exclude-findbugs.xml</findbugs.excludeFilterFile>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <azure-commons.version>0.1.4</azure-commons.version>
+        <azure-commons.version>0.2.4</azure-commons.version>
     </properties>
 
     <licenses>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -460,7 +460,8 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
                     zipArchiveBlob = serviceData.getArchiveBlobs().get(0);
                 }
 
-                run.addAction(new AzureBlobAction(run, storageAccountInfo.getStorageAccName(), expContainerName,
+                run.addAction(new AzureBlobAction(run, storageAccountInfo.getStorageAccName(),
+                        expContainerName, expShareName, storageType,
                         serviceData.getIndividualBlobs(), zipArchiveBlob, allowAnonymousAccess, storageCredentialId));
             }
         } catch (Exception e) {


### PR DESCRIPTION
fix issue https://github.com/jenkinsci/windows-azure-storage-plugin/issues/84: cannot download artifact.
The root cause is that the download link can only support Azure Blob Storage. Azure files are handled in the  same way as Azure blob. Definitely the blob cannot find and download as expected.