### PR TITLE
fix #85: blank window issue while configure storage credentials globally

### DIFF
--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher/global.jelly
@@ -23,7 +23,7 @@
                     </j:forEach>
                 </div>
                 <div align="center"> 
-                    <j:set var="credsAjaxURI" value="${rootURL}/${instance.getAjaxURI()}"/>
+                    <j:set var="credsAjaxURI" value="${rootURL}${instance.getAjaxURI()}"/>
                     <input type="button" class="yui-button" value="Add Storage Accounts" onclick="window.credentials.add('${credsAjaxURI}')" /> 
                     <p>
                         <a href="credentials/store/system/domain/_/" target="_blank">Manage Storage Accounts in Credential Store</a>


### PR DESCRIPTION
fix https://github.com/jenkinsci/windows-azure-storage-plugin/issues/85: blank window shown while configuring storage credentials in Jenkins Global configuration page.

It's caused by an extra forward slash in url. In cases where the context path is a empty string, the ajaxUrl becomes something like "//path...". The right url should be "/path..." starting with a single forward slash. The two have quite different meanings.

It happens to be right when the context path is not empty where the url "/jenkins//path..." is usually interpreted as the '/jenkins/path...'