### PR TITLE
fix jenkins-42341:marking build as UNSTABLE when no files downloaded

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -270,10 +270,8 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
             final StoragePluginService downloadService = getDownloadService(builderServiceData);
             int filesDownloaded = downloadService.execute();
 
-            if (filesDownloaded == 0) { // Mark build unstable if no files are
-                // downloaded
+            if (filesDownloaded == 0) {
                 listener.getLogger().println(Messages.AzureStorageBuilder_nofiles_downloaded());
-                run.setResult(Result.UNSTABLE);
             } else {
                 listener.getLogger().println(Messages.AzureStorageBuilder_files_downloaded_count(filesDownloaded));
             }

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
@@ -34,8 +34,8 @@ Client_SA_val_fail=Failed to validate storage account details. Please verify sto
 AzureStorageBuilder_displayName=Download from Azure storage
 AzureStorageBuilder_downloading=MicrosoftAzureStorage - Downloading files from Azure storage
 AzureStorageBuilder_ws_na=MicrosoftAzureStorage - Unable to get workspace location , if workspace is on slave make sure that slave is connected.
-AzureStorageBuilder_nofiles_downloaded=MicrosoftAzureStorage - Failed to download files from Azure storage.\
-                                       \n Verify that files exists with specified blob name
+AzureStorageBuilder_nofiles_downloaded=MicrosoftAzureStorage - No file was downloaded from Azure storage.\
+                                       \n Verify that files exist with specified blob or share.
 AzureStorageBuilder_files_downloaded_count=MicrosoftAzureStorage - Downloaded file count =  {0}
 AzureStorageBuilder_download_err=MicrosoftAzureStorage - Error occurred while downloading from Azure - {0}
 AzureStorageBuilder_blobName_req=Required: Enter Azure blob name


### PR DESCRIPTION
Fix issue 42341: https://issues.jenkins-ci.org/browse/JENKINS-42341.