### PR TITLE
Add credentials binding support for azure storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
             <version>1.20</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials-binding</artifactId>
+            <version>1.11</version>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding.java
@@ -1,0 +1,133 @@
+package com.microsoftopentechnologies.windowsazurestorage.helper;
+
+import com.microsoftopentechnologies.windowsazurestorage.Messages;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
+import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.Arrays;
+
+public class AzureCredentialsBinding extends MultiBinding<AzureCredentials> {
+    public static final String DEFAULT_STORAGE_ACCOUNT_NAME = "AZURE_STORAGE_ACCOUNT_NAME";
+    public static final String DEFAULT_STORAGE_ACCOUNT_KEY = "AZURE_STORAGE_ACCOUNT_KEY";
+    public static final String DEFAULT_BLOB_ENDPOINT_URL = "AZURE_BLOB_ENDPOINT_URL";
+
+    private String storageAccountNameVariable;
+    private String storageAccountKeyVariable;
+    private String blobEndpointUrlVariable;
+
+    @DataBoundConstructor
+    public AzureCredentialsBinding(String credentialsId) {
+        super(credentialsId);
+    }
+
+    @DataBoundSetter
+    public void setStorageAccountNameVariable(String storageAccountNameVariable) {
+        this.storageAccountNameVariable = storageAccountNameVariable;
+    }
+
+    @DataBoundSetter
+    public void setStorageAccountKeyVariable(String storageAccountKeyVariable) {
+        this.storageAccountKeyVariable = storageAccountKeyVariable;
+    }
+
+    @DataBoundSetter
+    public void setBlobEndpointUrlVariable(String blobEndpointUrlVariable) {
+        this.blobEndpointUrlVariable = blobEndpointUrlVariable;
+    }
+
+    public String getStorageAccountNameVariable() {
+        if (!StringUtils.isBlank(storageAccountNameVariable)) {
+            return storageAccountNameVariable;
+        }
+        return DEFAULT_STORAGE_ACCOUNT_NAME;
+    }
+
+    public String getStorageAccountKeyVariable() {
+        if (!StringUtils.isBlank(storageAccountKeyVariable)) {
+            return storageAccountKeyVariable;
+        }
+        return DEFAULT_STORAGE_ACCOUNT_KEY;
+    }
+
+    public String getBlobEndpointUrlVariable() {
+        if (!StringUtils.isBlank(blobEndpointUrlVariable)) {
+            return blobEndpointUrlVariable;
+        }
+        return DEFAULT_BLOB_ENDPOINT_URL;
+    }
+
+    @Override
+    protected Class<AzureCredentials> type() {
+        return AzureCredentials.class;
+    }
+
+    @Override
+    public MultiEnvironment bind(@Nonnull Run<?, ?> build,
+                                 @Nullable FilePath workspace,
+                                 @Nullable Launcher launcher,
+                                 @Nonnull TaskListener listener)
+            throws IOException {
+        AzureCredentials credentials = getCredentials(build);
+        Map<String, String> variableMap = new HashMap<>();
+        variableMap.put(getStorageAccountNameVariable(), credentials.getStorageAccountName());
+        variableMap.put(getStorageAccountKeyVariable(), credentials.getStorageKey());
+        variableMap.put(getBlobEndpointUrlVariable(), credentials.getBlobEndpointURL());
+        return new MultiEnvironment(variableMap);
+    }
+
+    @Override
+    public Set<String> variables() {
+        return new HashSet<>(Arrays.asList(
+                getStorageAccountNameVariable(),
+                getStorageAccountKeyVariable(),
+                getBlobEndpointUrlVariable()
+        ));
+    }
+
+    @Symbol("azureStorage")
+    @Extension
+    public static class DescriptorImpl extends BindingDescriptor<AzureCredentials> {
+        @Override
+        protected Class<AzureCredentials> type() {
+            return AzureCredentials.class;
+        }
+
+        @Override
+        public boolean requiresWorkspace() {
+            return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.AzureStorage_credentials_binding_display_name();
+        }
+
+        public static String getDefaultStorageAccountNameVariable() {
+            return DEFAULT_STORAGE_ACCOUNT_NAME;
+        }
+
+        public static String getDefaultStorageAccountKeyVariable() {
+            return DEFAULT_STORAGE_ACCOUNT_KEY;
+        }
+
+        public static String getDefaultBlobEndpointUrlVariable() {
+            return DEFAULT_BLOB_ENDPOINT_URL;
+        }
+    }
+}

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
@@ -43,5 +43,6 @@ AzureStorageBuilder_blobName_invalid=A blob name cannot be empty and must be bet
 AzureStorageBuilder_build_failed_err=MicrosoftAzureStorage - Build failed. Blob download cancelled.
 AzureStorageBuilder_downloadDir_invalid=The download path should be a directory not a file.
 AzureStorageBuilder_job_invalid=The job {0} does not exist
+AzureStorage_credentials_binding_display_name=Microsoft Azure Storage
 
 

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding/config-variables.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding/config-variables.jelly
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT License. See LICENSE file in the project root for license information.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials">
+    <f:entry title="${%StorageAccountNameVariable}" field="storageAccountNameVariable" help="/plugin/windows-azure-storage/help-storageAccountName.html">
+        <f:textbox default="${descriptor.getDefaultStorageAccountNameVariable()}"/>
+    </f:entry>
+    <f:entry title="${%StorageAccountKeyVariable}" field="storageAccountKeyVariable" help="/plugin/windows-azure-storage/help-storageAccountKey.html">
+        <f:textbox default="${descriptor.getDefaultStorageAccountKeyVariable()}"/>
+    </f:entry>
+    <f:entry title="${%BlobEndpointUrlVariable}" field="blobEndpointUrlVariable" help="/plugin/windows-azure-storage/help-blobEndPointURL.html">
+        <f:textbox default="${descriptor.getDefaultBlobEndpointUrlVariable()}"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding/config-variables.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding/config-variables.properties
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root for license information.
+
+StorageAccountNameVariable=Storage Account Name Variable
+StorageAccountKeyVariable=Storage Account Key Variable
+BlobEndpointUrlVariable=Blob Endpoint Url Variable


### PR DESCRIPTION
fix #99 : To use the credentials binding with Azure storage, use the following:

```
withCredentials([azureStorage(blobEndpointUrlVariable: 'BLOB_URL', credentialsId: 'CREDENTIALS_ID', storageAccountKeyVariable: 'STORAGE_KEY', storageAccountNameVariable: 'STORAGE_NAME')]) {
    sh '''
        echo "$BLOB_URL, $CREDENTIALS_ID, STORAGE_KEY, STORAGE_NAME"
    '''
}
```