### PR TITLE
Download items in several threads.

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromBuildService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromBuildService.java
@@ -88,6 +88,9 @@ public class DownloadFromBuildService extends DownloadService {
         try {
 
             final AzureBlobAction action = source.getAction(AzureBlobAction.class);
+            if (action == null) {
+                return filesNeedDownload;
+            }
             List<AzureBlob> azureBlobs = action.getIndividualBlobs();
             if (action.getZipArchiveBlob() != null && serviceData.isIncludeArchiveZips()) {
                 azureBlobs.addAll(Arrays.asList(action.getZipArchiveBlob()));

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromBuildService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromBuildService.java
@@ -84,7 +84,7 @@ public class DownloadFromBuildService extends DownloadService {
 
     private int downloadArtifacts(Run<?, ?> source) {
         final DownloadServiceData serviceData = getServiceData();
-        int filesDownloaded = 0;
+        int filesNeedDownload = 0;
         try {
 
             final AzureBlobAction action = source.getAction(AzureBlobAction.class);
@@ -92,16 +92,18 @@ public class DownloadFromBuildService extends DownloadService {
             if (action.getZipArchiveBlob() != null && serviceData.isIncludeArchiveZips()) {
                 azureBlobs.addAll(Arrays.asList(action.getZipArchiveBlob()));
             }
-
-            filesDownloaded = downloadBlobs(azureBlobs);
+            startDownloadThreads();
+            filesNeedDownload = scanBlobs(azureBlobs);
+            setFilesNeedDownload(filesNeedDownload);
+            setIsScanFinished(true);
+            waitForDownloadEnd();
         } catch (WAStorageException e) {
             setRunUnstable();
         }
-
-        return filesDownloaded;
+        return filesNeedDownload;
     }
 
-    private int downloadBlobs(List<AzureBlob> azureBlobs) throws WAStorageException {
+    private int scanBlobs(List<AzureBlob> azureBlobs) throws WAStorageException {
         final DownloadServiceData serviceData = getServiceData();
         int filesDownloaded = 0;
         println(Messages.AzureStorageBuilder_downloading());
@@ -126,7 +128,7 @@ public class DownloadFromBuildService extends DownloadService {
                                     null);
                         }
                         final CloudBlockBlob cbb = cloudBlobContainer.getBlockBlobReference(blob.getBlobName());
-                        downloadBlob(cbb);
+                        getDownloadItemDeque().push(cbb);
                         filesDownloaded++;
                     } else if (Constants.FILE_STORAGE.equalsIgnoreCase(blob.getStorageType())) {
                         if (cloudFileShare == null) {
@@ -139,7 +141,7 @@ public class DownloadFromBuildService extends DownloadService {
                                 filePath.indexOf(cloudFileShare.getName()) + cloudFileShare.getName().length() + 1);
                         final CloudFile cloudFile =
                                 cloudFileShare.getRootDirectoryReference().getFileReference(cloudFileName);
-                        downloadSingleFile(cloudFile);
+                        getDownloadItemDeque().push(cloudFile);
                         filesDownloaded++;
                     }
                 }

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromContainerService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromContainerService.java
@@ -16,7 +16,10 @@
 package com.microsoftopentechnologies.windowsazurestorage.service;
 
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlob;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlobDirectory;
+import com.microsoft.azure.storage.blob.ListBlobItem;
 import com.microsoftopentechnologies.windowsazurestorage.Messages;
 import com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException;
 import com.microsoftopentechnologies.windowsazurestorage.helper.AzureUtils;
@@ -33,7 +36,7 @@ public class DownloadFromContainerService extends DownloadService {
     @Override
     public int execute() {
         final DownloadServiceData serviceData = getServiceData();
-        int filesDownloaded = 0;
+        int filesNeedDownload = 0;
         try {
             println(Messages.AzureStorageBuilder_downloading());
             final CloudBlobContainer container = AzureUtils.getBlobContainerReference(
@@ -42,13 +45,49 @@ public class DownloadFromContainerService extends DownloadService {
                     false,
                     true,
                     null);
-            filesDownloaded = downloadBlobs(container.listBlobs());
+            startDownloadThreads();
+            filesNeedDownload = scanBlobs(container.listBlobs());
+            setFilesNeedDownload(filesNeedDownload);
+            setIsScanFinished(true);
+            waitForDownloadEnd();
         } catch (StorageException | URISyntaxException | IOException | WAStorageException e) {
             e.printStackTrace(error(Messages.AzureStorageBuilder_download_err(
                     serviceData.getStorageAccountInfo().getStorageAccName())));
             setRunUnstable();
         }
+        return filesNeedDownload;
+    }
 
-        return filesDownloaded;
+    protected int scanBlobs(Iterable<ListBlobItem> blobItems)
+            throws URISyntaxException, StorageException, WAStorageException {
+        final DownloadServiceData serviceData = getServiceData();
+        int filesNeedDownload = 0;
+        for (final ListBlobItem blobItem : blobItems) {
+            // If the item is a blob, not a virtual directory
+            if (blobItem instanceof CloudBlob) {
+                // Download the item and save it to a file with the same
+                final CloudBlob blob = (CloudBlob) blobItem;
+
+                // Check whether we should download it.
+                if (shouldDownload(
+                        serviceData.getIncludeFilesPattern(),
+                        serviceData.getExcludeFilesPattern(),
+                        blob.getName(),
+                        true)) {
+                    getDownloadItemDeque().push(blob);
+                    filesNeedDownload++;
+                }
+            } else if (blobItem instanceof CloudBlobDirectory) {
+                final CloudBlobDirectory blobDirectory = (CloudBlobDirectory) blobItem;
+                if (shouldDownload(
+                        serviceData.getIncludeFilesPattern(),
+                        serviceData.getExcludeFilesPattern(),
+                        blobDirectory.getPrefix(),
+                        false)) {
+                    filesNeedDownload+= scanBlobs(blobDirectory.listBlobs());
+                }
+            }
+        }
+        return filesNeedDownload;
     }
 }

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromContainerService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromContainerService.java
@@ -84,7 +84,7 @@ public class DownloadFromContainerService extends DownloadService {
                         serviceData.getExcludeFilesPattern(),
                         blobDirectory.getPrefix(),
                         false)) {
-                    filesNeedDownload+= scanBlobs(blobDirectory.listBlobs());
+                    filesNeedDownload += scanBlobs(blobDirectory.listBlobs());
                 }
             }
         }

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
@@ -37,6 +37,8 @@ AzureStorageBuilder_ws_na=MicrosoftAzureStorage - Unable to get workspace locati
 AzureStorageBuilder_nofiles_downloaded=MicrosoftAzureStorage - No file was downloaded from Azure storage.\
                                        \n Verify that files exist with specified blob or share.
 AzureStorageBuilder_files_downloaded_count=MicrosoftAzureStorage - Downloaded file count =  {0}
+AzureStorageBuilder_files_need_download_count=MicrosoftAzureStorage - Need to be downloaded file count =  {0}
+AzureStorageBuilder_download_timeout=MicrosoftAzureStorage - Download artifacts from Azure timeout of {0} {1}
 AzureStorageBuilder_download_err=MicrosoftAzureStorage - Error occurred while downloading from Azure - {0}
 AzureStorageBuilder_blobName_req=Required: Enter Azure blob name
 AzureStorageBuilder_blobName_invalid=A blob name cannot be empty and must be between one and 1,024 characters long


### PR DESCRIPTION
Fix issue #86 : azure storage plugin takes a lot of time especially when large numbers of files need to be downloaded. The origin design is scanning all the items and downloading one if it matches the requirements in a single thread. Now , a thread will scan all the items and put one into a queue if it matches the requirements. At the same time, several threads will check the queue and download the items.

I have made some tests on my laptop.

for container with 800 small files:

|Version|Round 1|Round 2|Round 3|AVG|
|--|--|--|--|--|
|old|9'2''|8'45''|9'15''|9'1''|
|new|46''|46''|46''|46''|

for share files with 800 small files:

|Version|Round 1|Round 2|Round 3|AVG|
|--|--|--|--|--|
|old|9'15''|9'29''|8'54''|9'13''|
|new|42''|40''|42''|41''|