### PR TITLE
Blue ocean artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
             <artifactId>credentials-binding</artifactId>
             <version>1.11</version>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.blueocean</groupId>
+            <artifactId>blueocean-rest</artifactId>
+            <version>1.3.5</version>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
@@ -96,6 +96,10 @@ public class AzureBlobAction implements RunAction {
         return containerName;
     }
 
+    public String getFileShareName() {
+        return fileShareName;
+    }
+
     @Exported
     public List<AzureBlob> getIndividualBlobs() {
         return individualBlobs;

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
@@ -1,5 +1,6 @@
 package com.microsoftopentechnologies.windowsazurestorage;
 
+import com.microsoftopentechnologies.windowsazurestorage.helper.Constants;
 import hudson.Extension;
 import hudson.model.Run;
 import io.jenkins.blueocean.rest.Reachable;
@@ -33,7 +34,7 @@ public final class AzureStorageBlueArtifact extends BlueArtifact {
 
     @Override
     public String getUrl() {
-        return String.format("/job/%s/%d/Azure/processDownloadRequest/%s", action.getContainerName(),
+        return String.format("/job/%s/%d/Azure/processDownloadRequest/%s", getStorageName(),
                 action.getBuild().number, artifact.getBlobName());
     }
 
@@ -45,6 +46,15 @@ public final class AzureStorageBlueArtifact extends BlueArtifact {
     @Override
     public boolean isDownloadable() {
         return true;
+    }
+
+    private String getStorageName() {
+        if (Constants.BLOB_STORAGE.equalsIgnoreCase(artifact.getStorageType())) {
+            return action.getContainerName();
+        } else if (Constants.FILE_STORAGE.equalsIgnoreCase(artifact.getStorageType())) {
+            return action.getFileShareName();
+        }
+        return "";
     }
 
     @Extension

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBlueArtifact.java
@@ -1,0 +1,65 @@
+package com.microsoftopentechnologies.windowsazurestorage;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import hudson.Extension;
+import hudson.model.Run;
+import io.jenkins.blueocean.rest.Reachable;
+import io.jenkins.blueocean.rest.factory.BlueArtifactFactory;
+import io.jenkins.blueocean.rest.hal.Link;
+import io.jenkins.blueocean.rest.model.BlueArtifact;
+
+import java.util.Collection;
+
+public final class AzureStorageBlueArtifact extends BlueArtifact {
+    private final AzureBlobAction action;
+    private final AzureBlob artifact;
+
+    public AzureStorageBlueArtifact(AzureBlobAction action, AzureBlob artifact, Link parent) {
+        super(parent);
+        this.action = action;
+        this.artifact = artifact;
+    }
+
+    @Override
+    public String getName() {
+        return artifact.getBlobName();
+    }
+
+    @Override
+    public String getPath() {
+        return artifact.getBlobURL();
+    }
+
+    @Override
+    public String getUrl() {
+        return artifact.getBlobURL();
+    }
+
+    @Override
+    public long getSize() {
+        return -1;
+    }
+
+    @Override
+    public boolean isDownloadable() {
+        return true;
+    }
+
+    @Extension
+    public static final class FactoryImpl extends BlueArtifactFactory {
+        @Override
+        public Collection<BlueArtifact> getArtifacts(Run<?, ?> run, final Reachable reachable) {
+            final AzureBlobAction action = run.getAction(AzureBlobAction.class);
+            if (action == null) {
+                return null;
+            }
+            return Collections2.transform(action.getIndividualBlobs(), new Function<AzureBlob, BlueArtifact>() {
+                @Override
+                public BlueArtifact apply(AzureBlob azureBlob) {
+                    return new AzureStorageBlueArtifact(action, azureBlob, reachable.getLink());
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Add feature referred in issue #101 .

Now Azure Storage artifacts can be seen or downloaded on blue ocean .

Shown as : 
![image](https://user-images.githubusercontent.com/6169722/37587351-0dd12d6c-2b9a-11e8-89c8-60548733bcca.png)
