### PR TITLE
Change container name validation for static website hosting

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
@@ -34,6 +34,12 @@ public final class Constants {
      */
     public static final String ROOT_CONTAINER = "$root";
 
+    /**
+     * @see <a href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website">
+     *     Working with the static website hosting Web Container</a>
+     */
+    public static final String WEB_CONTAINER = "$web";
+
     /* Regular expression to match tokens in the format of $TOKEN or ${TOKEN} */
     public static final String TOKEN_FORMAT = "\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_]+\\})";
 

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -41,14 +41,14 @@ public final class Utils {
      * followed by a letter or number; consecutive dashes are not permitted in
      * container names. 3.All letters in a container name must be lowercase.
      * 4.Container names must be from 3 through 63 characters long. 5.Root
-     * container is specially treated.
+     * container and web container are specially treated.
      *
      * @param containerName Name of the Windows Azure storage container
      * @return true if container name is valid else returns false
      */
     public static boolean validateContainerName(String containerName) {
         if (containerName != null) {
-            if (containerName.equals(Constants.ROOT_CONTAINER)) {
+            if (containerName.equals(Constants.ROOT_CONTAINER) || containerName.equals(Constants.WEB_CONTAINER)) {
                 return true;
             }
 

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/WindowsAzureStorageTest.java
@@ -24,6 +24,10 @@ public class WindowsAzureStorageTest extends TestCase {
 		// checking for container name with dash (-) characters
 		assertEquals(true, Utils.validateContainerName("abc-def"));
 
+        // checking for special container name
+        assertEquals(true, Utils.validateContainerName("$root"));
+        assertEquals(true, Utils.validateContainerName("$web"));
+
 		// Negative case : consecutive dashes are not allowed
 		assertEquals(false, Utils.validateContainerName("abc--def"));
 


### PR DESCRIPTION
Related with issues #119 .

[static website](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website)  is hosted in a special container named "$web". Change the container name validation rules to let it pass.