### PR TITLE
Fix storage key not masked issue

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentials.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentials.java
@@ -182,6 +182,10 @@ public class AzureCredentials extends BaseStandardCredentials {
         return storageData.storageAccountName;
     }
 
+    public String getPlainStorageKey() {
+        return storageData.storageAccountKey.getPlainText();
+    }
+
     public String getStorageKey() {
         return storageData.storageAccountKey.getEncryptedValue();
     }

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/AzureCredentialsBinding.java
@@ -86,7 +86,7 @@ public class AzureCredentialsBinding extends MultiBinding<AzureCredentials> {
         AzureCredentials credentials = getCredentials(build);
         Map<String, String> variableMap = new HashMap<>();
         variableMap.put(getStorageAccountNameVariable(), credentials.getStorageAccountName());
-        variableMap.put(getStorageAccountKeyVariable(), credentials.getStorageKey());
+        variableMap.put(getStorageAccountKeyVariable(), credentials.getPlainStorageKey());
         variableMap.put(getBlobEndpointUrlVariable(), credentials.getBlobEndpointURL());
         return new MultiEnvironment(variableMap);
     }


### PR DESCRIPTION
related issue #118 

Add plain secret instead of encrypted one to the binding environment. Because delegate output will use this binding to decide whether to mask the output value.