### PR TITLE
Fix naming convention rules not consist issue

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -18,6 +18,7 @@ package com.microsoftopentechnologies.windowsazurestorage;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.google.common.base.Strings;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
 import com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException;
 import com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials;
@@ -62,6 +63,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
     public static final String DOWNLOAD_TYPE_CONTAINER = "container";
@@ -256,14 +258,14 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
                     new DownloadServiceData(run, workspace, launcher, listener, storageAccountInfo);
 
             // Resolve include patterns
-            String expIncludePattern = Util.replaceMacro(includeFilesPattern, envVars);
+            String expIncludePattern = Utils.replaceMacro(includeFilesPattern, envVars);
             // If the include is empty, make **/*
             if (StringUtils.isBlank(expIncludePattern)) {
                 expIncludePattern = "**/*";
             }
 
             // Resolve exclude patterns
-            String expExcludePattern = Util.replaceMacro(excludeFilesPattern, envVars);
+            String expExcludePattern = Utils.replaceMacro(excludeFilesPattern, envVars);
             // Exclude archive.zip by default.
             if (!includeArchiveZips) {
                 if (expExcludePattern != null) {
@@ -273,12 +275,16 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
                 }
             }
 
+            // Resolve container name or share name
+            final String expContainerName = Utils.replaceMacro(Util.fixNull(containerName), envVars, Locale.ENGLISH);
+            final String expShareName = Utils.replaceMacro(Util.fixNull(fileShare), envVars, Locale.ENGLISH);
+
             // initialize service data
             builderServiceData.setIncludeFilesPattern(expIncludePattern);
             builderServiceData.setExcludeFilesPattern(expExcludePattern);
             builderServiceData.setDownloadDirLoc(Util.replaceMacro(downloadDirLoc, envVars));
-            builderServiceData.setContainerName(Util.replaceMacro(containerName, envVars));
-            builderServiceData.setFileShare(Util.replaceMacro(fileShare, envVars));
+            builderServiceData.setContainerName(expContainerName);
+            builderServiceData.setFileShare(expShareName);
             builderServiceData.setFlattenDirectories(flattenDirectories);
             builderServiceData.setDeleteFromAzureAfterDownload(deleteFromAzureAfterDownload);
             builderServiceData.setDownloadType(downloadType);

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -18,7 +18,6 @@ package com.microsoftopentechnologies.windowsazurestorage;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import com.google.common.base.Strings;
 import com.microsoftopentechnologies.windowsazurestorage.beans.StorageAccountInfo;
 import com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException;
 import com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials;

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -71,7 +71,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
     private final String storageType;
@@ -374,14 +373,6 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
         return storageAcc;
     }
 
-    public String replaceMacro(String s, Map<String, String> props, Locale locale) {
-        return Util.replaceMacro(s, props).trim().toLowerCase(locale);
-    }
-
-    public String replaceMacro(String s, Map<String, String> props) {
-        return Util.replaceMacro(s, props).trim();
-    }
-
     @Override
     public synchronized void perform(
             @Nonnull Run<?, ?> run,
@@ -401,8 +392,8 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
         final StorageAccountInfo storageAccountInfo = AzureCredentials.convertToStorageAccountInfo(credential);
 
         // Resolve container name or share name
-        final String expContainerName = replaceMacro(Util.fixNull(containerName), envVars, Locale.ENGLISH);
-        final String expShareName = replaceMacro(Util.fixNull(fileShareName), envVars, Locale.ENGLISH);
+        final String expContainerName = Utils.replaceMacro(Util.fixNull(containerName), envVars, Locale.ENGLISH);
+        final String expShareName = Utils.replaceMacro(Util.fixNull(fileShareName), envVars, Locale.ENGLISH);
 
         if (!validateData(run, listener, storageAccountInfo, expContainerName, expShareName)) {
             throw new IOException("Plugin can not continue, until previous errors are addressed");
@@ -411,8 +402,8 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
         final UploadServiceData serviceData = new UploadServiceData(run, ws, launcher, listener, storageAccountInfo);
         serviceData.setContainerName(expContainerName);
         serviceData.setFileShareName(expShareName);
-        serviceData.setFilePath(replaceMacro(Util.fixNull(filesPath), envVars));
-        serviceData.setExcludedFilesPath(replaceMacro(Util.fixNull(excludeFilesPath), envVars));
+        serviceData.setFilePath(Utils.replaceMacro(Util.fixNull(filesPath), envVars));
+        serviceData.setExcludedFilesPath(Utils.replaceMacro(Util.fixNull(excludeFilesPath), envVars));
         serviceData.setBlobProperties(blobProperties);
         serviceData.setPubAccessible(pubAccessible);
         serviceData.setCleanUpContainerOrShare(cleanUpContainerOrShare);
@@ -420,7 +411,7 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
         serviceData.setAzureBlobMetadata(metadata);
         serviceData.setOnlyUploadModifiedArtifacts(onlyUploadModifiedArtifacts);
         // Resolve virtual path
-        String expVP = replaceMacro(Util.fixNull(virtualPath), envVars);
+        String expVP = Utils.replaceMacro(Util.fixNull(virtualPath), envVars);
 
         if (!(StringUtils.isBlank(expVP) || expVP.endsWith(Constants.FWD_SLASH))) {
             expVP += Constants.FWD_SLASH;

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -227,7 +227,7 @@ public final class Utils {
     }
 
     /**
-     * wrapper of method {@link hudson.Util#replaceMacro(String, Map)}, make the result into lower case
+     * wrapper of method {@link hudson.Util#replaceMacro(String, Map)}, make the result into lower case.
      *
      * @param s
      * @param props
@@ -239,7 +239,7 @@ public final class Utils {
     }
 
     /**
-     * wrapper of method {@link hudson.Util#replaceMacro(String, Map)}, trim the result
+     * wrapper of method {@link hudson.Util#replaceMacro(String, Map)}, trim the result.
      *
      * @param s
      * @param props

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -235,7 +235,11 @@ public final class Utils {
      * @return
      */
     public static String replaceMacro(String s, Map<String, String> props, Locale locale) {
-        return Util.replaceMacro(s, props).trim().toLowerCase(locale);
+        String result = Util.replaceMacro(s, props);
+        if (result == null) {
+            return null;
+        }
+        return result.trim().toLowerCase(locale);
     }
 
     /**
@@ -246,7 +250,11 @@ public final class Utils {
      * @return
      */
     public static String replaceMacro(String s, Map<String, String> props) {
-        return Util.replaceMacro(s, props).trim();
+        String result = Util.replaceMacro(s, props);
+        if (result == null) {
+            return null;
+        }
+        return result.trim();
     }
 
     private Utils() {

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -17,6 +17,7 @@ package com.microsoftopentechnologies.windowsazurestorage.helper;
 
 import com.microsoft.azure.storage.OperationContext;
 import com.microsoft.azure.storage.core.BaseRequest;
+import hudson.Util;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 public final class Utils {
 
@@ -222,6 +224,29 @@ public final class Utils {
 
         opContext.setUserHeaders(temp);
         return opContext;
+    }
+
+    /**
+     * wrapper of method {@link hudson.Util#replaceMacro(String, Map)}, make the result into lower case
+     *
+     * @param s
+     * @param props
+     * @param locale
+     * @return
+     */
+    public static String replaceMacro(String s, Map<String, String> props, Locale locale) {
+        return Util.replaceMacro(s, props).trim().toLowerCase(locale);
+    }
+
+    /**
+     * wrapper of method {@link hudson.Util#replaceMacro(String, Map)}, trim the result
+     *
+     * @param s
+     * @param props
+     * @return
+     */
+    public static String replaceMacro(String s, Map<String, String> props) {
+        return Util.replaceMacro(s, props).trim();
     }
 
     private Utils() {


### PR DESCRIPTION
Use same replaceMacro for the same field in both publish and download process.
changes include:

- transfer replaceMacro methods from WAStoragePublisher.java to Utils.java
- use replaceMacro.tolowercase() for `containerName` and `sharefileName`
- use replaceMacro.trim() for `includeFilesPattern` and `excludeFilesPattern`

related issue #125 