### PR TITLE
Compat with old version when upgrading plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.20.1</version>
                 <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                     <excludes>
                         <exclude>InjectedTest.java</exclude>
                     </excludes>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
@@ -155,9 +155,9 @@ public class AzureBlobAction implements RunAction2 {
     }
 
     private String generateSASURL(StorageAccountInfo storageAccountInfo, String fileName) throws Exception {
-        if (storageType.equalsIgnoreCase(Constants.BLOB_STORAGE)) {
+        if (getStorageType().equalsIgnoreCase(Constants.BLOB_STORAGE)) {
             return AzureUtils.generateBlobSASURL(storageAccountInfo, containerName, fileName);
-        } else if (storageType.equalsIgnoreCase(Constants.FILE_STORAGE)) {
+        } else if (getStorageType().equalsIgnoreCase(Constants.FILE_STORAGE)) {
             return AzureUtils.generateFileSASURL(storageAccountInfo, fileShareName, fileName);
         }
 
@@ -170,5 +170,12 @@ public class AzureBlobAction implements RunAction2 {
 
     public Api getApi() {
         return new Api(this);
+    }
+
+    public String getStorageType() {
+        if (Constants.FILE_STORAGE.equals(storageType)) {
+            return storageType;
+        }
+        return Constants.BLOB_STORAGE;
     }
 }

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -121,7 +121,7 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setContainerName(String containerName) {
-        if (downloadType.equals(DOWNLOAD_TYPE_CONTAINER)) {
+        if (getDownloadType().equals(DOWNLOAD_TYPE_CONTAINER)) {
             this.containerName = containerName;
         }
     }
@@ -133,14 +133,14 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setBuildSelector(BuildSelector buildSelector) {
-        if (downloadType.equals(DOWNLOAD_TYPE_PROJECT)) {
+        if (getDownloadType().equals(DOWNLOAD_TYPE_PROJECT)) {
             this.buildSelector = buildSelector;
         }
     }
 
     @DataBoundSetter
     public void setProjectName(String projectName) {
-        if (downloadType.equals(DOWNLOAD_TYPE_PROJECT)) {
+        if (getDownloadType().equals(DOWNLOAD_TYPE_PROJECT)) {
             this.projectName = projectName;
         }
     }
@@ -175,7 +175,10 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
     }
 
     public String getDownloadType() {
-        return downloadType;
+        if (DOWNLOAD_TYPE_FILE_SHARE.equals(downloadType) || DOWNLOAD_TYPE_PROJECT.equals(downloadType)) {
+            return downloadType;
+        }
+        return DOWNLOAD_TYPE_CONTAINER;
     }
 
     public String getContainerName() {
@@ -286,7 +289,7 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
             builderServiceData.setFileShare(expShareName);
             builderServiceData.setFlattenDirectories(flattenDirectories);
             builderServiceData.setDeleteFromAzureAfterDownload(deleteFromAzureAfterDownload);
-            builderServiceData.setDownloadType(downloadType);
+            builderServiceData.setDownloadType(getDownloadType());
             builderServiceData.setProjectName(Util.replaceMacro(projectName, envVars));
             builderServiceData.setBuildSelector(buildSelector);
 
@@ -306,7 +309,7 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
     }
 
     private StoragePluginService getDownloadService(DownloadServiceData data) {
-        switch (this.downloadType) {
+        switch (getDownloadType()) {
             case DOWNLOAD_TYPE_FILE_SHARE:
                 return new DownloadFromFileService(data);
             case DOWNLOAD_TYPE_PROJECT:

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -440,7 +440,7 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
                 if (existAction != null) {
                     existAction.getIndividualBlobs().addAll(individualBlobs);
                 } else {
-                    run.addAction(new AzureBlobAction(expContainerName, expShareName, storageType,
+                    run.addAction(new AzureBlobAction(expContainerName, expShareName, getStorageType(),
                             individualBlobs, zipArchiveBlob, allowAnonymousAccess,
                             getStorageCredentialId()));
                 }


### PR DESCRIPTION
Fix #134 . Use get**Type() methods to give default value of blob storage since the previous version only support blobs.