### PR TITLE
Couldn't download artifacts, when there was a "/" in the blob name. 

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
@@ -17,6 +17,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.List;
+import static java.net.URLDecoder.decode;
 
 @ExportedBean
 public class AzureBlobAction implements RunAction2 {
@@ -139,10 +140,10 @@ public class AzureBlobAction implements RunAction2 {
         }
 
         for (AzureBlob blob : individualBlobs) {
-            if (blob.getBlobName().equals(blobName)) {
+            if (blobName.equals(decode(blob.getBlobName(), "UTF-8"))) {
                 try {
                     response.sendRedirect2(blob.getBlobURL() + "?"
-                            + generateSASURL(accountInfo, blobName));
+                            + generateSASURL(accountInfo, blob.getBlobName()));
                 } catch (Exception e) {
                     response.sendError(Constants.HTTP_INTERNAL_SERVER_ERROR,
                             "Error occurred while downloading artifact " + e.getMessage());

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
@@ -137,7 +137,7 @@ public class AzureBlobAction implements RunAction2 {
                 StandardCharsets.UTF_8.toString()))) {
             try {
                 response.sendRedirect2(zipArchiveBlob.getBlobURL() + "?"
-                        + generateSASURL(accountInfo, zipArchiveBlob.getBlobName()));
+                        + generateReadSASURL(accountInfo, zipArchiveBlob.getBlobName()));
             } catch (Exception e) {
                 response.sendError(Constants.HTTP_INTERNAL_SERVER_ERROR,
                         "Error occurred while downloading artifact " + e.getMessage());
@@ -149,7 +149,7 @@ public class AzureBlobAction implements RunAction2 {
             if (blobName.equals(URLDecoder.decode(blob.getBlobName(), StandardCharsets.UTF_8.toString()))) {
                 try {
                     response.sendRedirect2(blob.getBlobURL() + "?"
-                            + generateSASURL(accountInfo, blob.getBlobName()));
+                            + generateReadSASURL(accountInfo, blob.getBlobName()));
                 } catch (Exception e) {
                     response.sendError(Constants.HTTP_INTERNAL_SERVER_ERROR,
                             "Error occurred while downloading artifact " + e.getMessage());

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
@@ -17,7 +17,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.List;
-import static java.net.URLDecoder.decode;
+import java.net.URLDecoder;
 
 @ExportedBean
 public class AzureBlobAction implements RunAction2 {
@@ -140,7 +140,7 @@ public class AzureBlobAction implements RunAction2 {
         }
 
         for (AzureBlob blob : individualBlobs) {
-            if (blobName.equals(decode(blob.getBlobName(), "UTF-8"))) {
+            if (blobName.equals(URLDecoder.decode(blob.getBlobName(), "UTF-8"))) {
                 try {
                     response.sendRedirect2(blob.getBlobURL() + "?"
                             + generateSASURL(accountInfo, blob.getBlobName()));

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
@@ -18,6 +18,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.EnumSet;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.net.URLDecoder;

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobAction.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.net.URLDecoder;
 
@@ -128,10 +129,12 @@ public class AzureBlobAction implements RunAction2 {
         String blobName = queryPath.substring(1);
 
         // Check the archive blob if it is non-null
-        if (zipArchiveBlob != null && zipArchiveBlob.getBlobName().equals(blobName)) {
+        if (zipArchiveBlob != null
+                && blobName.equals(URLDecoder.decode(zipArchiveBlob.getBlobName(),
+                StandardCharsets.UTF_8.toString()))) {
             try {
                 response.sendRedirect2(zipArchiveBlob.getBlobURL() + "?"
-                        + generateSASURL(accountInfo, blobName));
+                        + generateSASURL(accountInfo, zipArchiveBlob.getBlobName()));
             } catch (Exception e) {
                 response.sendError(Constants.HTTP_INTERNAL_SERVER_ERROR,
                         "Error occurred while downloading artifact " + e.getMessage());
@@ -140,7 +143,7 @@ public class AzureBlobAction implements RunAction2 {
         }
 
         for (AzureBlob blob : individualBlobs) {
-            if (blobName.equals(URLDecoder.decode(blob.getBlobName(), "UTF-8"))) {
+            if (blobName.equals(URLDecoder.decode(blob.getBlobName(), StandardCharsets.UTF_8.toString()))) {
                 try {
                     response.sendRedirect2(blob.getBlobURL() + "?"
                             + generateSASURL(accountInfo, blob.getBlobName()));


### PR DESCRIPTION
Hey everyone,
we use the Pipeline Multibranch plugin for our integration with GitLab, so we get branch names with a "/" in it, which gets encoded to "%2F" and blob.getBlobName().equals(blobName) == false.

And because of that, it is impossible to download an artifact with a "/" in the name from our storage account. 

I did two things first of all I imported the URLDecoder library to compare the decoded names.
And then instead of using the blobName for the SAS URL, I used the blob.getBlobName() because the encoded blob Name is the one that is used to store the blob in Azure. 