### PR TITLE
Change default blob URL to https

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
@@ -43,7 +43,7 @@ public final class Constants {
     /* Regular expression to match tokens in the format of $TOKEN or ${TOKEN} */
     public static final String TOKEN_FORMAT = "\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_]+\\})";
 
-    public static final String DEF_BLOB_URL = "http://blob.core.windows.net/";
+    public static final String DEF_BLOB_URL = "https://blob.core.windows.net/";
     public static final String FWD_SLASH = "/";
     public static final String HTTP_PRT = "http://";
     // http Protocol separator

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Utils.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 public final class Utils {
 
-    public static final String DEF_BLOB_URL = "http://blob.core.windows.net/";
+    public static final String DEF_BLOB_URL = "https://blob.core.windows.net/";
     public static final String BLOB_ENDPOINT_ENDSUFFIX_KEYWORD = "core";
     public static final int BLOB_NAME_LENGTH_LIMIT = 1024;
 

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialMigrationTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialMigrationTest.java
@@ -58,7 +58,7 @@ public class CredentialMigrationTest {
     "<storageAccounts>\n" +
     "<storageAccName>abcdef</storageAccName>\n" +
     "<storageAccountKey>12345</storageAccountKey>\n" +
-    "<blobEndPointURL>http://blob.core.windows.net/</blobEndPointURL>\n" +
+    "<blobEndPointURL>https://blob.core.windows.net/</blobEndPointURL>\n" +
     "</storageAccounts>\n" +
     "</com.microsoftopentechnologies.windowsazurestorage.AzureStoragePublisher_-WAStorageDescriptor>";
     


### PR DESCRIPTION
The portal defaults to requiring https access, should be no reason these
days to default to http

I was confused why my setup was failing to validate, it took me a minute
of checking to notice that the default didn't work out of the box.

Small change that should be a good QoL improvement