### PR TITLE
Fix ConcurrentModificationException for blob actions

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -438,7 +438,10 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
                 List<AzureBlob> individualBlobs = serviceData.getIndividualBlobs();
                 AzureBlobAction existAction = run.getAction(AzureBlobAction.class);
                 if (existAction != null) {
-                    existAction.getIndividualBlobs().addAll(individualBlobs);
+                    List<AzureBlob> existActionIndividualBlobs = existAction.getIndividualBlobs();
+                    synchronized (existActionIndividualBlobs) {
+                        existActionIndividualBlobs.addAll(individualBlobs);
+                    }
                 } else {
                     run.addAction(new AzureBlobAction(expContainerName, expShareName, getStorageType(),
                             individualBlobs, zipArchiveBlob, allowAnonymousAccess,

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromBuildService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/DownloadFromBuildService.java
@@ -93,7 +93,9 @@ public class DownloadFromBuildService extends DownloadService {
             }
             List<AzureBlob> azureBlobs = action.getIndividualBlobs();
             if (action.getZipArchiveBlob() != null && serviceData.isIncludeArchiveZips()) {
-                azureBlobs.addAll(Arrays.asList(action.getZipArchiveBlob()));
+                synchronized (azureBlobs) {
+                    azureBlobs.addAll(Arrays.asList(action.getZipArchiveBlob()));
+                }
             }
             filesNeedDownload = scanBlobs(azureBlobs);
             println(Messages.AzureStorageBuilder_files_need_download_count(filesNeedDownload));


### PR DESCRIPTION
Synchronized the blob list to prevent the build serialization job to access it and throw `ConcurrentModificationException `.

[JENKINS-57553](https://issues.jenkins-ci.org/browse/JENKINS-57553)