### PR TITLE
Fix possible duplicating cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>2.9.9.1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToBlobService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToBlobService.java
@@ -60,8 +60,7 @@ public class UploadToBlobService extends UploadService {
         final UploadServiceData serviceData = getServiceData();
         try {
             final CloudBlobContainer container = getCloudBlobContainer();
-            UploadType uploadType = serviceData.getUploadType();
-            if (uploadType == UploadType.BOTH || uploadType == UploadType.INDIVIDUAL) {
+            if (serviceData.getUploadType() == UploadType.ZIP) {
                 cleanupContainer(container);
             }
 
@@ -123,7 +122,8 @@ public class UploadToBlobService extends UploadService {
         final UploadServiceData serviceData = getServiceData();
         try {
             final CloudBlobContainer container = getCloudBlobContainer();
-            if (serviceData.getUploadType() == UploadType.ZIP) {
+            UploadType uploadType = serviceData.getUploadType();
+            if (uploadType == UploadType.INDIVIDUAL || uploadType == UploadType.BOTH) {
                 cleanupContainer(container);
             }
 

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToBlobService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToBlobService.java
@@ -187,7 +187,8 @@ public class UploadToBlobService extends UploadService {
         return container;
     }
 
-    private void cleanupContainer(CloudBlobContainer container) throws StorageException, IOException, URISyntaxException {
+    private void cleanupContainer(CloudBlobContainer container) throws
+            StorageException, IOException, URISyntaxException {
         final UploadServiceData serviceData = getServiceData();
         // Delete previous contents if cleanup is needed
         if (serviceData.isCleanUpContainerOrShare()) {

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToBlobService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToBlobService.java
@@ -32,6 +32,7 @@ import com.microsoftopentechnologies.windowsazurestorage.helper.Constants;
 import com.microsoftopentechnologies.windowsazurestorage.helper.Utils;
 import com.microsoftopentechnologies.windowsazurestorage.service.model.PartialBlobProperties;
 import com.microsoftopentechnologies.windowsazurestorage.service.model.UploadServiceData;
+import com.microsoftopentechnologies.windowsazurestorage.service.model.UploadType;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.util.DirScanner;
@@ -59,6 +60,10 @@ public class UploadToBlobService extends UploadService {
         final UploadServiceData serviceData = getServiceData();
         try {
             final CloudBlobContainer container = getCloudBlobContainer();
+            UploadType uploadType = serviceData.getUploadType();
+            if (uploadType == UploadType.BOTH || uploadType == UploadType.INDIVIDUAL) {
+                cleanupContainer(container);
+            }
 
             final FilePath workspacePath = serviceData.getRemoteWorkspace();
             // Create a temp dir for the upload
@@ -118,6 +123,9 @@ public class UploadToBlobService extends UploadService {
         final UploadServiceData serviceData = getServiceData();
         try {
             final CloudBlobContainer container = getCloudBlobContainer();
+            if (serviceData.getUploadType() == UploadType.ZIP) {
+                cleanupContainer(container);
+            }
 
             List<UploadObject> uploadObjects = new ArrayList<>();
             for (FilePath src : paths) {
@@ -176,13 +184,17 @@ public class UploadToBlobService extends UploadService {
                 true,
                 serviceData.isPubAccessible());
 
+        return container;
+    }
+
+    private void cleanupContainer(CloudBlobContainer container) throws StorageException, IOException, URISyntaxException {
+        final UploadServiceData serviceData = getServiceData();
         // Delete previous contents if cleanup is needed
         if (serviceData.isCleanUpContainerOrShare()) {
             deleteBlobs(container.listBlobs());
         } else if (serviceData.isCleanUpVirtualPath() && StringUtils.isNotBlank(serviceData.getVirtualPath())) {
             deleteBlobs(container.getDirectoryReference(serviceData.getVirtualPath()).listBlobs());
         }
-        return container;
     }
 
     /**

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToFileService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadToFileService.java
@@ -129,7 +129,8 @@ public class UploadToFileService extends UploadService {
         if (serviceData.isCleanUpContainerOrShare() && fileShare.exists()) {
             println("Clean up existing files in  file share " + serviceData.getFileShareName());
             deleteFiles(fileShare.getRootDirectoryReference().listFilesAndDirectories());
-        } else if (serviceData.isCleanUpVirtualPath() && StringUtils.isNotBlank(serviceData.getVirtualPath()) && fileShare.exists()) {
+        } else if (serviceData.isCleanUpVirtualPath()
+                && StringUtils.isNotBlank(serviceData.getVirtualPath()) && fileShare.exists()) {
             CloudFileDirectory directory = fileShare.getRootDirectoryReference()
                     .getDirectoryReference(serviceData.getVirtualPath());
             if (directory.exists()) {


### PR DESCRIPTION
Inspired by reviewing #156.

The cleanup logic was put in the `getCloudBlobContainer` or `getCloudFileShare` method which is called when uploading individual files and archived file. So if one user chooses both cleanup  and uploading archived file. The individual files will be cleaned when uploading archived one.

Solution: When only uploading individual files or archived file, we will try to trigger cleanup. When we need to upload both of them, we only try to cleanup in the individual round since it is executed before the archived one.
