### PR TITLE
Fix wrong md5 value

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadService.java
@@ -41,6 +41,7 @@ import hudson.Util;
 import hudson.remoting.VirtualChannel;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.Jenkins;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -452,8 +453,8 @@ public abstract class UploadService extends StoragePluginService<UploadServiceDa
             String md;
             byte[] mdBytes;
             try (InputStream is = src.read()) {
-                md = DigestUtils.md5Hex(is);
                 mdBytes = DigestUtils.md5(is);
+                md = Hex.encodeHexString(mdBytes);
             }
 
             ImmutablePair<Integer, String> response;


### PR DESCRIPTION
Use several `DigestUtils.**` methods will consume the stream several times, causing the later one gets empty stream. This causes the `mdBytes`  always the same as empty file. Try to get the md5 value once and encode it here.