### PR TITLE
Upgrade to new jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.40</version>
+        <version>3.55</version>
     </parent>
 
 
@@ -23,8 +23,8 @@
         <findbugs.excludeFilterFile>exclude-findbugs.xml</findbugs.excludeFilterFile>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <azure-commons.version>1.0.4</azure-commons.version>
-        <configuration-as-code.version>1.10</configuration-as-code.version>
-        <jackson.version>2.10.0</jackson.version>
+        <configuration-as-code.version>1.35</configuration-as-code.version>
+        <jackson.version>2.10.2</jackson.version>
     </properties>
 
     <licenses>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.16</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -124,6 +124,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
             <version>4.12</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -150,15 +156,8 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
-            <artifactId>configuration-as-code-support</artifactId>
+            <artifactId>test-harness</artifactId>
             <version>${configuration-as-code.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
-            <version>${configuration-as-code.version}</version>
-            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/ConfigAsCodeTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/ConfigAsCodeTest.java
@@ -2,6 +2,7 @@ package com.microsoftopentechnologies.windowsazurestorage;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.casc.CredentialsRootConfigurator;
 import com.microsoftopentechnologies.windowsazurestorage.helper.AzureStorageAccount;
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.ConfigurationContext;
@@ -10,7 +11,6 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
-import io.jenkins.plugins.casc.support.credentials.CredentialsRootConfigurator;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/src/test/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialRenameTest.java
+++ b/src/test/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialRenameTest.java
@@ -5,80 +5,29 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.model.Item;
 import hudson.security.ACL;
-import jenkins.model.Jenkins;
-import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class CredentialRenameTest {
-    public static File input = new File("src/test/resources/com/microsoftopentechnologies/helper/correctFormatOldConfig.xml");
-    private Jenkins jenkinsInstance;
-    private static final String correctConfigContent =
-            "<?xml version='1.0' encoding='UTF-8'?>\n" +
-                    "<com.cloudbees.plugins.credentials.SystemCredentialsProvider plugin=\"credentials@2.1.18\">\n" +
-                    "  <domainCredentialsMap class=\"hudson.util.CopyOnWriteMap$Hash\">\n" +
-                    "    <entry>\n" +
-                    "      <com.cloudbees.plugins.credentials.domains.Domain>\n" +
-                    "        <specifications/>\n" +
-                    "      </com.cloudbees.plugins.credentials.domains.Domain>\n" +
-                    "      <java.util.concurrent.CopyOnWriteArrayList>\n" +
-                    "        <com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials plugin=\"windows-azure-storage@0.3.13-SNAPSHOT\">\n" +
-                    "          <scope>GLOBAL</scope>\n" +
-                    "          <id>jieshestorage</id>\n" +
-                    "          <description></description>\n" +
-                    "          <storageData>\n" +
-                    "            <storageAccountName>name</storageAccountName>\n" +
-                    "            <storageAccountKey>key</storageAccountKey>\n" +
-                    "            <blobEndpointURL>https://blob.core.windows.net/</blobEndpointURL>\n" +
-                    "          </storageData>\n" +
-                    "        </com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials>\n" +
-                    "      </java.util.concurrent.CopyOnWriteArrayList>\n" +
-                    "    </entry>\n" +
-                    "  </domainCredentialsMap>\n" +
-                    "</com.cloudbees.plugins.credentials.SystemCredentialsProvider>";
-
-    private static final String wrongConfigContent = "<?xml version='1.0' encoding='UTF-8'?>\n" +
-            "<com.microsoftopentechnologies.windowsazurestorage.AzureStoragePublisher_-WAStorageDescriptor plugin='windows-azure-storage@0.3.3-SNAPSHOT'>\n" +
-            "<storageAccounts>\n" +
-            "<storageAccName>abcdef</storageAccName>\n" +
-            "<storageAccountKey>12345</storageAccountKey>\n" +
-            "<blobEndPointURL>https://blob.core.windows.net/</blobEndPointURL>\n" +
-            "</storageAccounts>\n" +
-            "</com.microsoftopentechnologies.windowsazurestorage.AzureStoragePublisher_-WAStorageDescriptor>";
 
     @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
-    @ClassRule
-    public static JenkinsRule j = new JenkinsRule();
-
-    @Before
-    public void setUp() {
-        jenkinsInstance = Jenkins.getInstance();
-    }
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
+    @LocalData
     public void testRenameStorageConfig() throws Exception {
         String storageAccount = "name";
         String storageAccountKey = "key";
         String storageBlobURL = "https://blob.core.windows.net/";
-        File configFile = testFolder.newFile("credentials.xml");
-        FileUtils.writeStringToFile(configFile, correctConfigContent);
-        FileUtils.copyFileToDirectory(configFile, jenkinsInstance.root);
 
-        CredentialRename.renameStorageConfig();
-
-        CredentialsStore s = CredentialsProvider.lookupStores(jenkinsInstance).iterator().next();
+        CredentialsStore s = CredentialsProvider.lookupStores(j.jenkins).iterator().next();
 
         assertEquals(1, s.getCredentials(Domain.global()).size());
 
@@ -96,6 +45,5 @@ public class CredentialRenameTest {
         assertEquals(u.getStorageAccountName(), storageCred.getStorageAccountName());
         assertEquals(u.getEndpointURL(), storageCred.getBlobEndpointURL());
         assertEquals(u.getSecureKey().getPlainText(), storageCred.getPlainStorageKey());
-
     }
 }

--- a/src/test/resources/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialRenameTest/testRenameStorageConfig/credentials.xml
+++ b/src/test/resources/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialRenameTest/testRenameStorageConfig/credentials.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.plugins.credentials.SystemCredentialsProvider plugin="credentials@2.1.18">
+    <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
+        <entry>
+            <com.cloudbees.plugins.credentials.domains.Domain>
+                <specifications/>
+            </com.cloudbees.plugins.credentials.domains.Domain>
+            <java.util.concurrent.CopyOnWriteArrayList>
+                <com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials
+                        plugin="windows-azure-storage@0.3.13-SNAPSHOT">
+                    <scope>GLOBAL</scope>
+                    <id>jieshestorage</id>
+                    <description></description>
+                    <storageData>
+                        <storageAccountName>name</storageAccountName>
+                        <storageAccountKey>key</storageAccountKey>
+                        <blobEndpointURL>https://blob.core.windows.net/</blobEndpointURL>
+                    </storageData>
+                </com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials>
+            </java.util.concurrent.CopyOnWriteArrayList>
+        </entry>
+    </domainCredentialsMap>
+</com.cloudbees.plugins.credentials.SystemCredentialsProvider>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164