### PR TITLE
Calculate block size in SI base

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadService.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/service/UploadService.java
@@ -422,7 +422,8 @@ public abstract class UploadService extends StoragePluginService<UploadServiceDa
      */
     static class UploadThread implements Callable<UploadResult> {
         private UploadObject uploadObject;
-        private static final int BLOCK_SIZE = 100 * 1024 * 1024;
+        // Azure backend calculates block size in SI bytes
+        private static final int BLOCK_SIZE = 100 * 1000 * 1000;
         private static final String TEMP_FILE_PATTERN = "%s/%ssplit.%d";
         private static final Logger LOGGER = Logger.getLogger(UploadThread.class.getName());
 


### PR DESCRIPTION
Uploading files that were greater than `100 * 1000 * 1000` SI bytes (100 MB) would fail to upload due to a `400 Bad Request`.

```
ERROR: MicrosoftAzureStorage - Error occurred while uploading to Azure - sharedst01
com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException: Fail to upload individual files to blob
	at com.microsoftopentechnologies.windowsazurestorage.service.UploadToBlobService.uploadIndividuals(UploadToBlobService.java:151)
	at com.microsoftopentechnologies.windowsazurestorage.service.UploadService.execute(UploadService.java:719)
	at com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher.perform(WAStoragePublisher.java:438)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: java.util.concurrent.ExecutionException: com.microsoftopentechnologies.windowsazurestorage.exceptions.WAStorageException: Failed to upload application-release.zip with error code 400
	at com.microsoftopentechnologies.windowsazurestorage.service.UploadService$UploadOnSlave.invoke(UploadService.java:373)
	at com.microsoftopentechnologies.windowsazurestorage.service.UploadService$UploadOnSlave.invoke(UploadService.java:346)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3069)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	... 4 more
```

Azure backend appears to calculate the block size using [SI rather than normal binary calculation](https://en.wikipedia.org/wiki/Binary_prefix#Deviation_between_powers_of_1024_and_powers_of_1000).  Once making this change and using the modified plugin in our Jenkins instance, artifact uploads would successfully upload.