### PR TITLE
Simplify pipeline syntax generator

### DIFF
--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties.java
@@ -26,19 +26,19 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.Tika;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 public class AzureBlobProperties implements Describable<AzureBlobProperties> {
 
-    private final String cacheControl;
-    private final String contentEncoding;
-    private final String contentLanguage;
-    private final String contentType;
-    private final boolean detectContentType;
+    private String cacheControl;
+    private String contentEncoding;
+    private String contentLanguage;
+    private String contentType;
+    private boolean detectContentType = true;
 
-    @DataBoundConstructor
     public AzureBlobProperties(
             final String cacheControl,
             final String contentEncoding,
@@ -46,11 +46,15 @@ public class AzureBlobProperties implements Describable<AzureBlobProperties> {
             final String contentType,
             final boolean detectContentType
     ) {
-        this.cacheControl = cacheControl;
-        this.contentEncoding = contentEncoding;
-        this.contentLanguage = contentLanguage;
-        this.contentType = contentType;
+        this.cacheControl = Util.fixEmpty(cacheControl);
+        this.contentEncoding = Util.fixEmpty(contentEncoding);
+        this.contentLanguage = Util.fixEmpty(contentLanguage);
+        this.contentType = Util.fixEmpty(contentType);
         this.detectContentType = detectContentType;
+    }
+
+    @DataBoundConstructor
+    public AzureBlobProperties() {
     }
 
     public String getCacheControl() {
@@ -71,6 +75,31 @@ public class AzureBlobProperties implements Describable<AzureBlobProperties> {
 
     public boolean getDetectContentType() {
         return detectContentType;
+    }
+
+    @DataBoundSetter
+    public void setCacheControl(String cacheControl) {
+        this.cacheControl = Util.fixEmpty(cacheControl);
+    }
+
+    @DataBoundSetter
+    public void setContentEncoding(String contentEncoding) {
+        this.contentEncoding = Util.fixEmpty(contentEncoding);
+    }
+
+    @DataBoundSetter
+    public void setContentLanguage(String contentLanguage) {
+        this.contentLanguage = Util.fixEmpty(contentLanguage);
+    }
+
+    @DataBoundSetter
+    public void setContentType(String contentType) {
+        this.contentType = Util.fixEmpty(contentType);
+    }
+
+    @DataBoundSetter
+    public void setDetectContentType(boolean detectContentType) {
+        this.detectContentType = detectContentType;
     }
 
     public void configure(CloudBlob blob, FilePath src, EnvVars env) throws InterruptedException, IOException {

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/AzureStorageBuilder.java
@@ -128,7 +128,7 @@ public class AzureStorageBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setFileShare(String fileShare) {
-        this.fileShare = fileShare;
+        this.fileShare = Util.fixEmpty(fileShare);
     }
 
     @DataBoundSetter

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/WAStoragePublisher.java
@@ -114,7 +114,7 @@ public class WAStoragePublisher extends Recorder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setFileShareName(String fileShareName) {
-        this.fileShareName = fileShareName;
+        this.fileShareName = Util.fixEmpty(fileShareName);
     }
 
     @DataBoundSetter

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/Constants.java
@@ -49,9 +49,13 @@ public final class Constants {
     // http Protocol separator
     //CHECKSTYLE:OFF
     public static final String PRT_SEP = "://";
-    public static final String LEGACY_STORAGE_CONFIG_FILE = "com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher.xml";
+    public static final String LEGACY_STORAGE_CONFIG_FILE =
+            "com.microsoftopentechnologies.windowsazurestorage.WAStoragePublisher.xml";
     public static final String HASH_TYPE = "MD5";
-    public static final String CREDENTIALS_AJAX_URI = "/descriptor/com.cloudbees.plugins.credentials.CredentialsSelectHelper/resolver/com.cloudbees.plugins.credentials.CredentialsSelectHelper$SystemContextResolver/provider/com.cloudbees.plugins.credentials.SystemCredentialsProvider$ProviderImpl/context/jenkins/dialog";
+    public static final String CREDENTIALS_AJAX_URI = "/descriptor/com.cloudbees.plugins.credentials." +
+            "CredentialsSelectHelper/resolver/com.cloudbees.plugins.credentials.CredentialsSelectHelper" +
+            "$SystemContextResolver/provider/com.cloudbees.plugins.credentials.SystemCredentialsProvider" +
+            "$ProviderImpl/context/jenkins/dialog";
     public static final String PLUGIN_NAME = "AzureJenkinsStorage";
     //CHECKSTYLE:ON
 

--- a/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialRename.java
+++ b/src/main/java/com/microsoftopentechnologies/windowsazurestorage/helper/CredentialRename.java
@@ -16,6 +16,7 @@
 
 package com.microsoftopentechnologies.windowsazurestorage.helper;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -69,11 +70,8 @@ public final class CredentialRename {
         }
         Path path = Paths.get(sourceFile.getCanonicalPath());
 
-        try (Stream<String> stream = Files.lines(path)) {
-            boolean needRename = stream.anyMatch(s -> s.contains(SOURCE_CONTENT));
-            if (!needRename) {
-                return;
-            }
+        if (renameNotNeededFor(path)) {
+            return;
         }
 
         LOGGER.log(Level.INFO, sourceFile + " exists, rename azure storage credential will start now...");
@@ -90,6 +88,17 @@ public final class CredentialRename {
         }
 
         removeFile(backUp.getCanonicalPath());
+    }
+
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Bug in spotbugs for try-with-resources
+    private static boolean renameNotNeededFor(Path path) throws IOException {
+        try (Stream<String> stream = Files.lines(path)) {
+            boolean needRename = stream.anyMatch(s -> s.contains(SOURCE_CONTENT));
+            if (!needRename) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void removeFile(String sourceFile) {

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobMetadataPair/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobMetadataPair/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry title="${%MetadataKey_title}" field="key">

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProjectAction/jobMain.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProjectAction/jobMain.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="lastSuccessfulArtifactsAction" value="${it.lastSuccessfulArtifactsAction}"/>
   <j:set var="listCutoff" value="${it.maxResultsDisplay}"/>

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/config.jelly
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/AzureBlobProperties/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%cacheControl_title}" field="cacheControl">
         <f:textbox />

--- a/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
+++ b/src/main/resources/com/microsoftopentechnologies/windowsazurestorage/Messages.properties
@@ -1,53 +1,59 @@
 # WAStoragePublisher_java
-WAStoragePublisher_displayName=Upload artifacts to Microsoft Azure Storage
-WAStoragePublisher_build_failed_err=MicrosoftAzureStorage - Build failed, hence canceling the upload of the artifacts to Azure storage
-WAStoragePublisher_storage_account_err=MicrosoftAzureStorage - Storage account information not found
-WAStoragePublisher_container_name_err=MicrosoftAzureStorage - Container name is missing or not valid
-WAStoragePublisher_filepath_err=MicrosoftAzureStorage - List of files to upload must not be empty
-WAStoragePublisher_container_name=MicrosoftAzureStorage - Container name: {0}
-WAStoragePublisher_share_name=MicrosoftAzureStorage - share name: {0}
-WAStoragePublisher_filepath=MicrosoftAzureStorage - File path: {0}
-WAStoragePublisher_virtualpath=MicrosoftAzureStorage - Virtual path: {0}
-WAStoragePublisher_excludepath=MicrosoftAzureStorage - Exclude path: {0}
-WAStoragePublisher_uploading=MicrosoftAzureStorage - Uploading files to Microsoft Azure
-WAStoragePublisher_nofiles_uploaded=MicrosoftAzureStorage - Failed to find any build artifacts to upload to Azure Storage \
-                                    \nVerify the list of files to upload and that the Ant glob syntax is correct
-WAStoragePublisher_files_uploaded_count=MicrosoftAzureStorage - Uploaded/archived file count = {0}
-WAStoragePublisher_files_need_upload_count=MicrosoftAzureStorage - Need uploaded/archived file count = {0}
-WAStoragePublisher_uploaded_err=MicrosoftAzureStorage - Error occurred while uploading to Azure - {0}
-WAStoragePublisher_uploaded_timeout=MicrosoftAzureStorage - Uploading artifacts to Azure fails due to timeout after {0} {1}
+WAStoragePublisher_displayName=Upload artifacts to Azure Storage
+WAStoragePublisher_build_failed_err=AzureStorage - Build failed, hence canceling the upload of the artifacts \
+  to Azure storage
+WAStoragePublisher_storage_account_err=AzureStorage - Storage account information not found
+WAStoragePublisher_container_name_err=AzureStorage - Container name is mi§ssing or not valid
+WAStoragePublisher_filepath_err=AzureStorage - List of files to upload must not be empty
+WAStoragePublisher_container_name=AzureStorage - Container name: {0}
+WAStoragePublisher_share_name=AzureStorage - share name: {0}
+WAStoragePublisher_filepath=AzureStorage - File path: {0}
+WAStoragePublisher_virtualpath=AzureStorage - Virtual path: {0}
+WAStoragePublisher_excludepath=AzureStorage - Exclude path: {0}
+WAStoragePublisher_uploading=AzureStorage - Uploading files to Azure
+WAStoragePublisher_nofiles_uploaded=AzureStorage - Failed to find any build artifacts to upload to Azure \
+  Storage\nVerify the list of files to upload and that the Ant glob syntax is correct
+WAStoragePublisher_files_uploaded_count=AzureStorage - Uploaded/archived file count = {0}
+WAStoragePublisher_files_need_upload_count=AzureStorage - Need uploaded/archived file count = {0}
+WAStoragePublisher_uploaded_err=AzureStorage - Error occurred while uploading to Azure - {0}
+WAStoragePublisher_uploaded_timeout=AzureStorage - Uploading artifacts to Azure fails due to timeout after \
+  {0} {1}
 WAStoragePublisher_storage_name_req=Required: Enter Azure storage account name
 WAStoragePublisher_storage_key_req=Required: Enter Azure storage account key
 WAStoragePublisher_container_name_req=Required: Enter container name
 WAStoragePublisher_share_name_req=Required: Enter file share name
 WAStoragePublisher_artifacts_req=Required: Enter names of artifacts to upload
-WAStoragePublisher_container_name_invalid=Container name must be between 3 and 63 characters, start with a letter or number, \
-                                          contain only letters, numbers and dashes (-). \
-                                          (Note that consecutive dashes are not allowed and dash cannot be the last character)
+WAStoragePublisher_container_name_invalid=Container name must be between 3 and 63 characters, start with a letter \
+   or number, \
+   contain only letters, numbers and dashes (-). \
+   (Note that consecutive dashes are not allowed and dash cannot be the last character)
 WAStoragePublisher_share_name_invalid=Share name must be between 3 and 63 characters, start with a letter or number, \
-                                          contain only letters, numbers and dashes (-). \
-                                          (Note that consecutive dashes are not allowed and dash cannot be the last character)
+  contain only letters, numbers and dashes (-). \
+  (Note that consecutive dashes are not allowed and dash cannot be the last character)
 WAStoragePublisher_SA_val=Validation successful
-WAStoragePublisher_uploadtype_invalid=No artifacts will be uploaded.  Either check "Upload zipped archive" or uncheck "Do not upload individual files"
+WAStoragePublisher_uploadtype_invalid=No artifacts will be uploaded.  Either check "Upload zipped archive" or uncheck \
+  "Do not upload individual files"
 # Properties in WAStorageClient_java
 Client_SA_val_fail=Failed to validate storage account details. Please verify storage account name and key. \
-                            If you are using a private or other Windows Azure cloud service, make sure that the blob endpoint url is correct.
+  If you are using a private or other Azure cloud service, make sure that the \
+  blob endpoint url is correct.
 #Properties in AzureStorageBuilder
 AzureStorageBuilder_displayName=Download from Azure storage
-AzureStorageBuilder_downloading=MicrosoftAzureStorage - Downloading files from Azure storage
-AzureStorageBuilder_ws_na=MicrosoftAzureStorage - Unable to get workspace location , if workspace is on slave make sure that slave is connected.
-AzureStorageBuilder_nofiles_downloaded=MicrosoftAzureStorage - No file was downloaded from Azure storage.\
+AzureStorageBuilder_downloading=AzureStorage - Downloading files from Azure storage
+AzureStorageBuilder_ws_na=AzureStorage - Unable to get workspace location , if workspace is on slave make \
+  sure that slave is connected.
+AzureStorageBuilder_nofiles_downloaded=AzureStorage - No file was downloaded from Azure storage.\
                                        \n Verify that files exist with specified blob or share.
-AzureStorageBuilder_files_downloaded_count=MicrosoftAzureStorage - Downloaded file count =  {0}
-AzureStorageBuilder_files_need_download_count=MicrosoftAzureStorage - Need to be downloaded file count =  {0}
-AzureStorageBuilder_download_timeout=MicrosoftAzureStorage - Download artifacts from Azure timeout of {0} {1}
-AzureStorageBuilder_download_err=MicrosoftAzureStorage - Error occurred while downloading from Azure - {0}
+AzureStorageBuilder_files_downloaded_count=AzureStorage - Downloaded file count =  {0}
+AzureStorageBuilder_files_need_download_count=AzureStorage - Need to be downloaded file count =  {0}
+AzureStorageBuilder_download_timeout=AzureStorage - Download artifacts from Azure timeout of {0} {1}
+AzureStorageBuilder_download_err=AzureStorage - Error occurred while downloading from Azure - {0}
 AzureStorageBuilder_blobName_req=Required: Enter Azure blob name
 AzureStorageBuilder_blobName_invalid=A blob name cannot be empty and must be between one and 1,024 characters long
-AzureStorageBuilder_build_failed_err=MicrosoftAzureStorage - Build failed. Blob download cancelled.
+AzureStorageBuilder_build_failed_err=AzureStorage - Build failed. Blob download cancelled.
 AzureStorageBuilder_downloadDir_invalid=The download path should be a directory not a file.
 AzureStorageBuilder_job_invalid=The job {0} does not exist
-AzureStorage_credentials_binding_display_name=Microsoft Azure Storage
+AzureStorage_credentials_binding_display_name=Azure Storage
 
 UploadService_https_uploaded=Uploaded to file storage with uri {0} in {1}
 UploadService_https_uploaded_fail=Failed to upload, error code: {0}, details {1}

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
- 	Azure Blob Storage Plugin enables uploading build <br />
- 	artifacts to, or downloading blob files from, Microsoft Azure Blob storage
+ 	Azure Blob Storage Plugin enables uploading build artifacts and downloading blob files from Azure Blob storage.
 </div>

--- a/src/main/webapp/help-storageaccounts.html
+++ b/src/main/webapp/help-storageaccounts.html
@@ -1,5 +1,5 @@
 <div>
-The list of storage accounts configured within the Jenkins Master
+The list of storage accounts configured within the Jenkins controller
 <br />
 Unique ids of each storage accounts are followed by the storage account names in brackets
 <br />


### PR DESCRIPTION
Empty strings won't show up for optional fields anymore

```
azureDownload containerName: 'jenkins', downloadType: 'container', includeFilesPattern: 'hello*.txt', storageCredentialId: 'storage'
```

```
azureUpload blobProperties: [], containerName: 'jenkins', filesPath: 'hello*.txt', storageCredentialId: 'storage', storageType: 'blobstorage'
```

not sure how to get rid of the empty blob properties but better than it was anyway